### PR TITLE
feat: add Antigravity answer unit protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Compile
-        run: python -m py_compile scripts/harness.py tests/test_harness.py
+        run: >-
+          python -m py_compile
+          scripts/harness.py
+          scripts/antigravity_adapter.py
+          tests/test_harness.py
+          tests/test_antigravity_adapter.py
       - name: Unit and contract tests
         run: python -m unittest discover -s tests -v
       - name: Validate committed JSON examples
         run: |
           python -m json.tool contracts/experiment.schema.json >/dev/null
           python -m json.tool contracts/answer.schema.json >/dev/null
+          python -m json.tool contracts/answer-unit.schema.json >/dev/null
           python -m json.tool contracts/adjudication.schema.json >/dev/null
           python -m json.tool experiments/template/experiment.json.example >/dev/null
           python -m json.tool experiments/template/questions.json.example >/dev/null

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 > порог oracle alignment, а индексный arm не показал преимущества в этом run.
 
 > Обобщение результата требует повторов и человеческой предметной приёмки.
-> Следующие этапы также имеют внешние prerequisites: точная старая платформа и
-> второй arm-proven coding-agent client.
+> Второй клиент Antigravity завершил тот же технический контракт, но получил
+> 31/47 и не прошёл общий порог качества. Для legacy-этапа по-прежнему нужна
+> точная старая платформа.
 
 ## Цель MVP
 
@@ -51,6 +52,7 @@ MVP считается полезным не потому, что агент н�
 - [Результат SDMS A/B](docs/sdms-evaluation.md)
 - [Подтверждённая граница совместимости](docs/compatibility.md)
 - [Готовность агентных клиентов](docs/client-readiness.md)
+- [Результат Antigravity arm](docs/antigravity-evaluation.md)
 - [Правила работы кодового агента](AGENTS.md)
 
 ## Evidence harness
@@ -59,8 +61,14 @@ MVP считается полезным не потому, что агент н�
 
 ```bash
 python3 scripts/harness.py --help
-python3 -m unittest -v tests/test_harness.py
+python3 -m unittest -v tests/test_harness.py tests/test_antigravity_adapter.py
 ```
+
+Для внешних клиентов harness также умеет fail-closed проверять небольшие
+`answer unit` результаты и детерминированно собирать полный `answer.json`:
+`verify-unit → assemble-answer → verify-answer`. Модель формирует содержание, а
+frozen IDs, client identity, metrics, порядок и финальную сериализацию добавляет
+обычный код.
 
 Крупные snapshots, raw answers, transcripts, индексы и полный oracle остаются в `.local/`. В Git публикуется только redacted evidence без закрытого кода и секретов.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,9 +48,11 @@ workspace нет. Этап не закрыт до появления закон�
 
 **Гейт:** различия ограничены адаптером или инструкциями клиента; evals используют общий набор вопросов и доказательств; абстракции для гипотетических клиентов не добавлены.
 
-**Статус:** Antigravity canary-proven, но два frozen arm attempts упали до answer
-artifact; standalone альтернативные CLI не установлены. Этап не закрыт; см.
-[`docs/client-readiness.md`](docs/client-readiness.md).
+**Статус:** Antigravity завершил общий технический контракт: 7/7 answers и 27
+locators прошли harness. Независимая оценка дала 31/47 и 0 опасных ложных
+выводов; общий порог 90% не пройден. Техническая независимость подтверждена, но
+этап не закрыт до quality-passing второго arm; см.
+[`docs/antigravity-evaluation.md`](docs/antigravity-evaluation.md).
 
 ## После read-only MVP
 

--- a/contracts/answer-unit.schema.json
+++ b/contracts/answer-unit.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/Kwentin3/1c-agent-harness/contracts/answer.schema.json",
-  "title": "1C evidence-backed answer",
+  "$id": "https://github.com/Kwentin3/1c-agent-harness/contracts/answer-unit.schema.json",
+  "title": "One evidence-backed answer work unit",
   "$defs": {
     "claim": {
       "type": "object",
@@ -22,8 +22,10 @@
         "endLine": {"type": "integer", "minimum": 1},
         "claimIds": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
       }
-    },
-    "answerUnit": {
+    }
+  },
+  "allOf": [
+    {
       "type": "object",
       "additionalProperties": false,
       "required": ["questionId", "answer", "facts", "inferences", "assumptions", "unknowns", "locators"],
@@ -37,26 +39,5 @@
         "locators": {"type": "array", "items": {"$ref": "#/$defs/locator"}}
       }
     }
-  },
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["schemaVersion", "experimentId", "snapshotContentId", "questionSetSha256", "client", "answers", "metrics"],
-  "properties": {
-    "schemaVersion": {"const": 1},
-    "experimentId": {"type": "string", "minLength": 1},
-    "snapshotContentId": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
-    "questionSetSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
-    "client": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "version"],
-      "properties": {"name": {"type": "string", "minLength": 1}, "version": {"type": "string", "minLength": 1}}
-    },
-    "answers": {
-      "type": "array",
-      "minItems": 1,
-      "items": {"$ref": "#/$defs/answerUnit"}
-    },
-    "metrics": {"type": "object", "additionalProperties": true}
-  }
+  ]
 }

--- a/docs/antigravity-evaluation.md
+++ b/docs/antigravity-evaluation.md
@@ -1,0 +1,83 @@
+# Результат Antigravity arm
+
+## Контракт и воспроизводимость
+
+Antigravity был проверен на том же frozen эксперименте, что и Hermes arms:
+
+- experiment: `sdms-product-eval-20260825`;
+- snapshot content ID: `sha256:3357ee63204ff863aac116417927240930084dce0eb7613126ad88cff68a424d`;
+- question set SHA-256: `3eba62e70085d74f954968832f5c5d9ab06db0c0da44e83af6bf22651fcbcd90`;
+- AgentBridge Antigravity CLI: `1.1.15`;
+- итоговый answer SHA-256: `94e7f3b1c5497156dbb4801c3d61c7ad5f2e93cbd0ef8576242201039d220fbc`.
+
+Runner получил отдельный read-only bundle снимка. Oracle, ответы других arms и их
+transcripts клиенту не передавались. Один frozen question выполнялся одной
+ограниченной research task. Семь принятых units потребовали восемь attempts: Q4
+один раз завершился `result_schema_invalid` и был повторён по заранее
+зафиксированной retry policy.
+
+Каждый native task record был преобразован строгим representation adapter без
+семантического repair. Harness отдельно проверил каждый unit, собрал полный ответ
+в frozen question order и повторно проверил итог. Результат: 7/7 вопросов,
+27 существующих locators, правильные content/question IDs. Повторная сборка из
+units, client descriptor и metrics дала побайтово тот же answer SHA-256. Post-run
+preflight подтвердил прежние 2581 файла snapshot и тот же content ID.
+
+Локальные task records, raw answers, oracle и snapshot остаются в `.local/` и не
+публикуются в Git.
+
+## Общая оценка
+
+Независимый adjudicator применил тот же frozen 47-item oracle, что использовался
+для baseline и indexed candidate.
+
+| Arm | Oracle alignment | Dangerous false claims | Наблюдаемое время |
+|---|---:|---:|---:|
+| Hermes direct source | 45/47 (95,74%) | 0 | 154 с |
+| Hermes indexes + source fallback | 44/47 (93,62%) | 0 | 204 с |
+| AgentBridge Antigravity | 31/47 (65,96%) | 0 | 1364 с |
+
+Разбивка Antigravity:
+
+| Вопрос | Зачтено |
+|---|---:|
+| Q1 — паспорт | 6/6 |
+| Q2 — назначение и масштаб | 8/9 |
+| Q3 — цепочка создания задачи | 5/9 |
+| Q4 — движения трудозатрат | 4/6 |
+| Q5 — регламентный механизм и мессенджеры | 3/5 |
+| Q6 — Bearer/JWT | 4/6 |
+| Q7 — существенные unknowns | 1/6 |
+
+Antigravity сохранил безопасную границу: опасная ложная декларация о доказанной
+криптографической проверке JWT не появилась, а runtime-состояние в основном не
+выдавалось за факт. Основная потеря качества — неполные составные ответы: были
+опущены части статической цепочки Q3, детали движений Q4, срок и обновление даты
+использования в Q6 и большинство заранее зарегистрированных категорий Q7.
+
+Есть и ограничение oracle: Q5 требует конкретный пример
+`ПересчитатьОчередьЗадач`, тогда как Antigravity выбрал другой реально
+существующий механизм `ОбновитьIDПользователейМессенджера`. По строгому frozen
+scoring этот item не засчитан; менять oracle после run нельзя.
+
+## Вывод
+
+Архитектурная граница подтверждена частично и проверяемо:
+
+- второй клиент прочитал тот же snapshot и вопросы;
+- snapshot contract и правила locators не стали client-specific;
+- различия ограничены read-only transport, инструкцией клиента и тонким adapter;
+- общий harness принял и проверил итоговый артефакт;
+- универсальный SDK или абстракция третьего клиента не созданы.
+
+При этом Antigravity arm не прошёл общий порог
+`minimumFactAccuracy = 0.9`: для 47 items нужно не менее 43, получено 31. Поэтому
+`arm-proven` здесь означает доказанный полный технический прогон, а не
+эквивалентное качество модели. Issue #4 нельзя закрывать только на основании
+этого run.
+
+Для воспроизведения требуется внешняя предпосылка: авторизованный AgentBridge
+Antigravity runner с read-only монтированием того же bundle. Следующий минимальный
+эксперимент — повторить заранее неизменный unit protocol с более явными
+per-question completeness requirements либо другим реально доступным клиентом,
+не меняя oracle после запуска.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,36 @@ Hermes Project Workspace предоставляет проекту файлов�
 
 Машинная форма закреплена в `contracts/answer.schema.json`. Сопоставимость эксперимента задаёт `contracts/experiment.schema.json`, а предметная оценка двух frozen arms — `contracts/adjudication.schema.json`. Автоматическая проверка locators не заменяет независимый эталон.
 
+### Изолированный внешний клиент
+
+Большой итоговый JSON не является обязанностью LLM. Для внешнего клиента контракт
+разделён на владельцев:
+
+```text
+immutable snapshot/questions → внешний runner → один answer unit
+                                          ↓
+                         deterministic assembly → answer.json
+                                          ↓
+                                  harness verification
+```
+
+- transport клиента владеет lifecycle и своим native envelope;
+- LLM владеет содержанием одного `answer unit`;
+- experiment владеет snapshot/question identity;
+- runner владеет фактическими client version и metrics;
+- `assemble-answer` проверяет полный набор units, добавляет системные metadata и
+  собирает итог в frozen question order;
+- `verify-answer` независимо повторяет snapshot и locator gates.
+
+`contracts/answer-unit.schema.json` повторяет ровно один элемент `answers[]` из
+полного контракта. Adapter может только извлечь это представление: он не чинит
+JSON, не переименовывает claims, не добавляет defaults и не классифицирует
+утверждения. Путь runner workspace, bundle ID, MCP task ID и native envelope не
+входят в доменную схему ответа.
+
+Это минимальная граница для двух реально используемых клиентов, а не SDK или
+framework для гипотетического третьего клиента.
+
 ## Native-first, не native-only
 
 Платформа 1С должна выполнять операции, для которых она является наиболее надёжным источником истины: выгрузку, проверку формата и позднее — загрузку или синтаксический контроль. Файловые инструменты обеспечивают быстрый поиск и агентную навигацию.

--- a/docs/client-protocol.md
+++ b/docs/client-protocol.md
@@ -25,6 +25,30 @@ Harness фиксирует контракт исследования, а не AP
 - `locators`: относительный путь и строки, связанные с claim IDs;
 - фактические client/model/tool versions и метрики.
 
+Клиент может вернуть полный документ сразу либо один work unit на вопрос. Unit
+имеет форму одного элемента `answers[]` и закреплён в
+`contracts/answer-unit.schema.json`. При unit-пути модель не повторяет
+`experimentId`, content IDs, client identity или metrics: эти значения добавляет
+детерминированный assembler из authoritative inputs.
+
+```bash
+python3 scripts/harness.py verify-unit \
+  --experiment .local/experiments/<id>/experiment.json \
+  --unit .local/experiments/<id>/runs/<arm>/Q1.json \
+  --output .local/experiments/<id>/runs/<arm>/Q1.verified.json
+
+python3 scripts/harness.py assemble-answer \
+  --experiment .local/experiments/<id>/experiment.json \
+  --unit .local/experiments/<id>/runs/<arm>/Q1.json \
+  --client .local/experiments/<id>/runs/<arm>/client.json \
+  --metrics .local/experiments/<id>/runs/<arm>/metrics.json \
+  --output .local/experiments/<id>/runs/<arm>/answer.json
+```
+
+`--unit` повторяется для каждого frozen question. Порядок аргументов не является
+authority: assembler использует порядок из `questions.json` и fail-closed
+отклоняет missing, extra и duplicate question IDs.
+
 Имя объекта, текстовый match или результат индекса сами по себе не доказывают назначение, runtime-состояние или call graph.
 
 ## Client-specific слой
@@ -35,6 +59,12 @@ Harness фиксирует контракт исследования, а не AP
 - sandbox/read-only permissions;
 - выбор реально доступной модели;
 - объявленная версия клиента.
+
+Client-specific representation adapter находится вне общего доменного
+контракта. Например, `scripts/antigravity_adapter.py` принимает только terminal
+task record, требует один JSON object в `summary` и пустые остальные поля native
+research envelope. Он не выполняет schema/locator verification и не ремонтирует
+malformed output — это остаётся общей обязанностью harness.
 
 Нельзя вводить общий SDK, plugin framework или скрывать различия context budget/model. `scripts/harness.py` намеренно не запускает клиентов.
 

--- a/docs/client-readiness.md
+++ b/docs/client-readiness.md
@@ -10,21 +10,18 @@ canary-proven → arm-proven.
 |---|---|---|
 | Hermes subagent, baseline | arm-proven | 7/7 ответов, machine-valid locators, 45/47 oracle facts |
 | Hermes subagent, indexed candidate | arm-proven | тот же контракт, 44/47 facts; индексы не приняты в MVP |
-| AgentBridge Antigravity | canary-proven | auth ready, `AGY_READY`; два frozen arm attempts завершились `cli_exit_nonzero` |
+| AgentBridge Antigravity | arm-proven, quality gate failed | 7/7 machine-valid answers, 27 locators, 31/47 oracle facts, 0 dangerous false claims |
 | standalone Codex/Claude/OpenCode/Gemini CLI | not installed | executable не найден в текущем workspace runtime |
 
-Canary Antigravity доказывает bridge runner и credential context, но не доступ к
-локальному snapshot. Оба attempts одной и той же frozen задачи упали до создания
-answer artifact, поэтому считать Antigravity вторым работающим клиентом нельзя.
+Завершённый Antigravity arm доказывает, что bridge runner видит bounded read-only
+bundle и может вернуть проверяемый артефакт общего контракта. Это не доказывает
+равное качество модели: 31/47 ниже общего порога 90%. `arm-proven` описывает
+техническую готовность поверхности, а не прохождение предметного eval.
 
-## Внешняя предпосылка второго arm
+## Внешняя предпосылка воспроизведения
 
-Нужен один из вариантов:
-
-1. исправленный Antigravity runner с read-only доступом к выбранному workspace;
-2. установленный и однократно авторизованный второй coding-agent CLI, который
-   поддерживает headless запуск и явную read-only policy.
-
-После этого клиент получает без изменений snapshot content ID, question hash,
-answer schema и locator rules из [`client-protocol.md`](client-protocol.md). Новый
-универсальный adapter или третий гипотетический клиент не требуется.
+Нужен авторизованный AgentBridge Antigravity runner с read-only монтированием
+того же bundle. Клиент получает без изменений snapshot content ID, question
+hash и locator rules из [`client-protocol.md`](client-protocol.md). Native
+envelope извлекается тонким adapter без semantic repair. Подробный результат и
+ограничения: [`antigravity-evaluation.md`](antigravity-evaluation.md).

--- a/docs/experiment-runbook.md
+++ b/docs/experiment-runbook.md
@@ -66,6 +66,26 @@ symlink/hard-link и размещение output/cache вне snapshot.
 
 Индекс или иной candidate-tool обязан хранить cache в объявленном `.local` cache root. Отрицательный результат индекса перепроверяется чтением XML/BSL.
 
+Для внешнего клиента с ограниченным output envelope предпочтителен unit-run:
+
+1. один frozen question → один новый task;
+2. native task record сохраняется неизменным;
+3. client adapter извлекает ровно один `answer-unit.schema.json` payload;
+4. `verify-unit` сразу проверяет форму, claim references и locators;
+5. итог публикуется только когда присутствуют все frozen question IDs.
+
+Пример строгого Antigravity extraction без repair:
+
+```bash
+python3 scripts/antigravity_adapter.py extract-unit \
+  --task-record .local/experiments/<id>/runs/<arm>/Q1.task.json \
+  --output .local/experiments/<id>/runs/<arm>/Q1.json
+```
+
+Retry policy фиксируется до запуска. Невалидный unit не разрешается вручную
+редактировать, дополнять данными другого arm или превращать эвристикой в новый
+семантический ответ.
+
 ## 5. Проверить ответы
 
 ```bash

--- a/scripts/antigravity_adapter.py
+++ b/scripts/antigravity_adapter.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Strict representation adapter for one Antigravity answer work unit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import stat
+import sys
+from typing import Any
+
+
+class AdapterError(RuntimeError):
+    pass
+
+
+def reject_symlink_path(path: Path, label: str) -> None:
+    absolute = path.absolute()
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        try:
+            mode = current.lstat().st_mode
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(mode):
+            raise AdapterError(f"{label} contains a symlink: {current}")
+
+
+def strict_json_loads(data: str, label: str) -> Any:
+    def object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise AdapterError(f"duplicate JSON key in {label}: {key}")
+            result[key] = value
+        return result
+
+    def reject_non_finite(value: str) -> Any:
+        raise AdapterError(f"non-finite JSON number in {label}: {value}")
+
+    return json.loads(
+        data,
+        object_pairs_hook=object_without_duplicates,
+        parse_constant=reject_non_finite,
+    )
+
+
+def read_object(path: Path, label: str) -> dict[str, Any]:
+    reject_symlink_path(path, label)
+    if not path.is_file():
+        raise AdapterError(f"{label} must be a regular non-symlink file")
+    try:
+        value = strict_json_loads(path.read_text(encoding="utf-8-sig"), label)
+    except (OSError, UnicodeError, json.JSONDecodeError, AdapterError) as exc:
+        raise AdapterError(f"invalid {label}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AdapterError(f"{label} must be a JSON object")
+    return value
+
+
+def extract_unit(task: dict[str, Any]) -> dict[str, Any]:
+    if task.get("status") != "completed":
+        raise AdapterError("task status must be completed")
+    result = task.get("result")
+    if not isinstance(result, dict):
+        raise AdapterError("task result must be an object")
+    result_keys = {"summary", "findings", "risks", "recommendations", "sources"}
+    if set(result) != result_keys:
+        raise AdapterError("task result must contain exactly the native five-field envelope")
+    for name in ("findings", "risks", "recommendations", "sources"):
+        if result[name] != []:
+            raise AdapterError(f"task result {name} must be empty for a typed unit")
+    summary = result.get("summary")
+    if not isinstance(summary, str):
+        raise AdapterError("task result summary must be a string")
+    try:
+        unit = strict_json_loads(summary, "summary")
+    except (json.JSONDecodeError, AdapterError) as exc:
+        raise AdapterError(f"invalid summary JSON: {exc}") from exc
+    if not isinstance(unit, dict):
+        raise AdapterError("summary JSON must be an object")
+    return unit
+
+
+def write_new(path: Path, value: dict[str, Any]) -> None:
+    reject_symlink_path(path, "output")
+    if path.exists() or path.is_symlink():
+        raise AdapterError(f"refusing existing output: {path}")
+    if not path.parent.is_dir() or path.parent.is_symlink():
+        raise AdapterError("output parent must be an existing non-symlink directory")
+    try:
+        data = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    except (TypeError, ValueError) as exc:
+        raise AdapterError(f"output is not strict JSON: {exc}") from exc
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            stream.write(data)
+    except FileExistsError as exc:
+        raise AdapterError(f"refusing existing output: {path}") from exc
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    commands = result.add_subparsers(dest="command", required=True)
+    command = commands.add_parser("extract-unit")
+    command.add_argument("--task-record", type=Path, required=True)
+    command.add_argument("--output", type=Path, required=True)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        task = read_object(args.task_record, "task record")
+        write_new(args.output, extract_unit(task))
+    except AdapterError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/harness.py
+++ b/scripts/harness.py
@@ -18,6 +18,25 @@ class ContractError(RuntimeError):
     pass
 
 
+def strict_json_loads(data: str) -> Any:
+    def object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ContractError(f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    def reject_non_finite(value: str) -> Any:
+        raise ContractError(f"non-finite JSON number is not allowed: {value}")
+
+    return json.loads(
+        data,
+        object_pairs_hook=object_without_duplicates,
+        parse_constant=reject_non_finite,
+    )
+
+
 def digest_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -36,8 +55,8 @@ def read_json_hashed(path: Path, label: str) -> tuple[dict[str, Any], str]:
         raise ContractError(f"{label} is not a regular file: {path}")
     try:
         data = path.read_bytes()
-        value = json.loads(data.decode("utf-8-sig"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        value = strict_json_loads(data.decode("utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError, ContractError) as exc:
         raise ContractError(f"invalid {label}: {exc}") from exc
     if not isinstance(value, dict):
         raise ContractError(f"{label} must be a JSON object")
@@ -79,6 +98,8 @@ def is_within(path: Path, root: Path) -> bool:
 
 
 def require_keys(value: dict[str, Any], keys: Iterable[str], label: str) -> None:
+    if any(not isinstance(key, str) for key in value):
+        raise ContractError(f"{label} keys must be strings")
     missing = sorted(set(keys) - value.keys())
     if missing:
         raise ContractError(f"{label} missing keys: {', '.join(missing)}")
@@ -241,6 +262,51 @@ def claim_ids(items: Any, label: str) -> set[str]:
     return result
 
 
+def verify_answer_entry(entry: Any, root: Path) -> tuple[str, int]:
+    if not isinstance(entry, dict):
+        raise ContractError("answer unit must be an object")
+    entry_keys = ("questionId", "answer", "facts", "inferences", "assumptions", "unknowns", "locators")
+    require_contract_keys(entry, entry_keys, entry_keys, "answer unit")
+    if not isinstance(entry["questionId"], str) or not entry["questionId"] or not isinstance(entry["answer"], str):
+        raise ContractError("answer unit questionId must be non-empty and answer must be a string")
+    ids: set[str] = set()
+    for label in ("facts", "inferences", "assumptions", "unknowns"):
+        current = claim_ids(entry[label], label)
+        duplicate = ids & current
+        if duplicate:
+            raise ContractError(f"claim ids must be unique within an answer: {sorted(duplicate)}")
+        ids |= current
+    if not isinstance(entry["locators"], list):
+        raise ContractError("locators must be an array")
+    locator_count = 0
+    for locator in entry["locators"]:
+        if not isinstance(locator, dict):
+            raise ContractError("each locator must be an object")
+        locator_keys = ("path", "startLine", "endLine", "claimIds")
+        require_contract_keys(locator, locator_keys, locator_keys, "locator")
+        rel = safe_relative(locator["path"], "locator path")
+        target = root.joinpath(*rel.parts)
+        reject_symlink_path(target, f"locator {rel.as_posix()}")
+        if not target.is_file() or not is_within(target, root):
+            raise ContractError(f"locator file does not exist inside snapshot: {rel.as_posix()}")
+        start, end = locator["startLine"], locator["endLine"]
+        if not isinstance(start, int) or isinstance(start, bool) or not isinstance(end, int) or isinstance(end, bool) or start < 1 or end < start:
+            raise ContractError(f"invalid locator line range: {rel.as_posix()}:{start}-{end}")
+        try:
+            line_count = len(target.read_text(encoding="utf-8-sig").splitlines())
+        except (OSError, UnicodeError) as exc:
+            raise ContractError(f"locator file is not readable UTF-8 text: {rel.as_posix()}: {exc}") from exc
+        if end > line_count:
+            raise ContractError(f"locator line range exceeds file: {rel.as_posix()}:{start}-{end}, lines={line_count}")
+        claim_ids_value = locator["claimIds"]
+        if not isinstance(claim_ids_value, list) or not claim_ids_value or any(x not in ids for x in claim_ids_value):
+            raise ContractError(f"locator claimIds must reference claims in the same answer: {rel.as_posix()}")
+        if len(claim_ids_value) != len(set(claim_ids_value)):
+            raise ContractError(f"locator claimIds must be unique: {rel.as_posix()}")
+        locator_count += 1
+    return entry["questionId"], locator_count
+
+
 def verify_answer_doc(spec: dict[str, Any], answer_path: Path) -> dict[str, Any]:
     state = verify_snapshot(spec)
     doc, answer_sha256 = read_json_hashed(answer_path, "answer")
@@ -269,47 +335,9 @@ def verify_answer_doc(spec: dict[str, Any], answer_path: Path) -> dict[str, Any]
     locator_count = 0
     root: Path = spec["_snapshotRoot"]
     for entry in doc["answers"]:
-        if not isinstance(entry, dict):
-            raise ContractError("each answer entry must be an object")
-        entry_keys = ("questionId", "answer", "facts", "inferences", "assumptions", "unknowns", "locators")
-        require_contract_keys(entry, entry_keys, entry_keys, "answer entry")
-        if not isinstance(entry["questionId"], str) or not isinstance(entry["answer"], str):
-            raise ContractError("answer questionId and answer must be strings")
-        seen_questions.append(entry["questionId"])
-        ids: set[str] = set()
-        for label in ("facts", "inferences", "assumptions", "unknowns"):
-            current = claim_ids(entry[label], label)
-            duplicate = ids & current
-            if duplicate:
-                raise ContractError(f"claim ids must be unique within an answer: {sorted(duplicate)}")
-            ids |= current
-        if not isinstance(entry["locators"], list):
-            raise ContractError("locators must be an array")
-        for locator in entry["locators"]:
-            if not isinstance(locator, dict):
-                raise ContractError("each locator must be an object")
-            locator_keys = ("path", "startLine", "endLine", "claimIds")
-            require_contract_keys(locator, locator_keys, locator_keys, "locator")
-            rel = safe_relative(locator["path"], "locator path")
-            target = root.joinpath(*rel.parts)
-            reject_symlink_path(target, f"locator {rel.as_posix()}")
-            if not target.is_file() or not is_within(target, root):
-                raise ContractError(f"locator file does not exist inside snapshot: {rel.as_posix()}")
-            start, end = locator["startLine"], locator["endLine"]
-            if not isinstance(start, int) or isinstance(start, bool) or not isinstance(end, int) or isinstance(end, bool) or start < 1 or end < start:
-                raise ContractError(f"invalid locator line range: {rel.as_posix()}:{start}-{end}")
-            try:
-                line_count = len(target.read_text(encoding="utf-8-sig").splitlines())
-            except (OSError, UnicodeError) as exc:
-                raise ContractError(f"locator file is not readable UTF-8 text: {rel.as_posix()}: {exc}") from exc
-            if end > line_count:
-                raise ContractError(f"locator line range exceeds file: {rel.as_posix()}:{start}-{end}, lines={line_count}")
-            claim_ids_value = locator["claimIds"]
-            if not isinstance(claim_ids_value, list) or not claim_ids_value or any(x not in ids for x in claim_ids_value):
-                raise ContractError(f"locator claimIds must reference claims in the same answer: {rel.as_posix()}")
-            if len(claim_ids_value) != len(set(claim_ids_value)):
-                raise ContractError(f"locator claimIds must be unique: {rel.as_posix()}")
-            locator_count += 1
+        question_id, current_locator_count = verify_answer_entry(entry, root)
+        seen_questions.append(question_id)
+        locator_count += current_locator_count
     if seen_questions != state["questionIds"]:
         raise ContractError(f"answer question order/set mismatch: expected {state['questionIds']}, got {seen_questions}")
     if not isinstance(doc["metrics"], dict):
@@ -325,7 +353,10 @@ def write_new_json(path: Path, value: dict[str, Any]) -> None:
     reject_symlink_path(parent, "output parent")
     if not parent.is_dir():
         raise ContractError(f"output parent must already exist: {parent}")
-    data = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    try:
+        data = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    except (TypeError, ValueError) as exc:
+        raise ContractError(f"output is not strict JSON: {exc}") from exc
     try:
         with path.open("x", encoding="utf-8", newline="\n") as stream:
             stream.write(data)
@@ -352,6 +383,57 @@ def verify_answer(args: argparse.Namespace) -> dict[str, Any]:
         "answerSha256": checked["answerSha256"],
         "snapshotContentId": checked["state"]["snapshotContentId"],
         "questionSetSha256": checked["state"]["questionSetSha256"],
+    }
+
+
+def verify_unit(args: argparse.Namespace) -> dict[str, Any]:
+    spec = load_experiment(args.experiment)
+    state = verify_snapshot(spec)
+    unit, unit_sha256 = read_json_hashed(args.unit, "answer unit")
+    question_id, locator_count = verify_answer_entry(unit, spec["_snapshotRoot"])
+    if question_id not in state["questionIds"]:
+        raise ContractError(f"answer unit questionId is not in frozen question set: {question_id}")
+    return {
+        "schemaVersion": 1,
+        "status": "ok",
+        "experimentId": spec["id"],
+        "questionId": question_id,
+        "locatorCount": locator_count,
+        "unitSha256": unit_sha256,
+        "snapshotContentId": state["snapshotContentId"],
+        "questionSetSha256": state["questionSetSha256"],
+    }
+
+
+def assemble_answer(args: argparse.Namespace) -> dict[str, Any]:
+    spec = load_experiment(args.experiment)
+    state = verify_snapshot(spec)
+    client = read_json(args.client, "client descriptor")
+    require_contract_keys(client, ("name", "version"), ("name", "version"), "client descriptor")
+    if any(not isinstance(client[key], str) or not client[key] for key in ("name", "version")):
+        raise ContractError("client descriptor name and version must be non-empty strings")
+    metrics = read_json(args.metrics, "metrics")
+    units: dict[str, dict[str, Any]] = {}
+    root: Path = spec["_snapshotRoot"]
+    for path in args.unit:
+        unit = read_json(path, "answer unit")
+        question_id, _ = verify_answer_entry(unit, root)
+        if question_id in units:
+            raise ContractError(f"duplicate answer unit questionId: {question_id}")
+        units[question_id] = unit
+    expected = state["questionIds"]
+    if set(units) != set(expected):
+        missing = sorted(set(expected) - set(units))
+        extra = sorted(set(units) - set(expected))
+        raise ContractError(f"answer unit question set mismatch; missing={missing}, extra={extra}")
+    return {
+        "schemaVersion": 1,
+        "experimentId": spec["id"],
+        "snapshotContentId": state["snapshotContentId"],
+        "questionSetSha256": state["questionSetSha256"],
+        "client": client,
+        "answers": [units[question_id] for question_id in expected],
+        "metrics": metrics,
     }
 
 
@@ -432,11 +514,15 @@ def seal(args: argparse.Namespace) -> dict[str, Any]:
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     commands = result.add_subparsers(dest="command", required=True)
-    for name in ("preflight", "verify-answer", "compare", "seal"):
+    for name in ("preflight", "verify-unit", "verify-answer", "assemble-answer", "compare", "seal"):
         command = commands.add_parser(name)
         command.add_argument("--experiment", type=Path, required=True)
         command.add_argument("--output", type=Path, required=True)
     commands.choices["verify-answer"].add_argument("--answer", type=Path, required=True)
+    commands.choices["verify-unit"].add_argument("--unit", type=Path, required=True)
+    commands.choices["assemble-answer"].add_argument("--unit", type=Path, action="append", required=True)
+    commands.choices["assemble-answer"].add_argument("--client", type=Path, required=True)
+    commands.choices["assemble-answer"].add_argument("--metrics", type=Path, required=True)
     commands.choices["compare"].add_argument("--baseline", type=Path, required=True)
     commands.choices["compare"].add_argument("--candidate", type=Path, required=True)
     commands.choices["compare"].add_argument("--adjudication", type=Path, required=True)
@@ -446,7 +532,7 @@ def parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = parser().parse_args()
-    handlers = {"preflight": preflight, "verify-answer": verify_answer, "compare": compare, "seal": seal}
+    handlers = {"preflight": preflight, "verify-unit": verify_unit, "verify-answer": verify_answer, "assemble-answer": assemble_answer, "compare": compare, "seal": seal}
     try:
         spec = load_experiment(args.experiment)
         if not is_within(args.output.absolute(), spec["_outputRoot"]):

--- a/tests/test_antigravity_adapter.py
+++ b/tests/test_antigravity_adapter.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts" / "antigravity_adapter.py"
+
+
+class AntigravityAdapterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.output = self.root / "unit.json"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def run_cli(self, task: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(CLI), "extract-unit", "--task-record", str(task), "--output", str(self.output)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def task_record(self, summary: str, **overrides: object) -> dict[str, object]:
+        result: dict[str, object] = {
+            "summary": summary,
+            "findings": [],
+            "risks": [],
+            "recommendations": [],
+            "sources": [],
+        }
+        result.update(overrides)
+        return {"task_id": "task-1", "status": "completed", "result": result}
+
+    def test_extracts_exact_small_unit_from_summary(self) -> None:
+        unit = {
+            "questionId": "Q1",
+            "answer": "Confirmed.",
+            "facts": [{"id": "F1", "text": "A fact."}],
+            "inferences": [],
+            "assumptions": [],
+            "unknowns": [],
+            "locators": [],
+        }
+        task = self.root / "task.json"
+        task.write_text(json.dumps(self.task_record(json.dumps(unit, ensure_ascii=False))) + "\n")
+
+        result = self.run_cli(task)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(self.output.read_text()), unit)
+
+    def test_refuses_competing_native_fields_without_output(self) -> None:
+        task = self.root / "task.json"
+        task.write_text(json.dumps(self.task_record("{}", findings=["extra"])) + "\n")
+
+        result = self.run_cli(task)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be empty", result.stderr.lower())
+        self.assertFalse(self.output.exists())
+
+    def test_refuses_malformed_summary_without_repair(self) -> None:
+        task = self.root / "task.json"
+        task.write_text(json.dumps(self.task_record('{"questionId":"Q1",}')) + "\n")
+
+        result = self.run_cli(task)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid summary json", result.stderr.lower())
+        self.assertFalse(self.output.exists())
+
+    def test_refuses_duplicate_summary_keys_without_output(self) -> None:
+        task = self.root / "task.json"
+        duplicate = '{"questionId":"Q1","questionId":"Q2"}'
+        task.write_text(json.dumps(self.task_record(duplicate)) + "\n")
+
+        result = self.run_cli(task)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("duplicate json key", result.stderr.lower())
+        self.assertFalse(self.output.exists())
+
+    def test_refuses_output_below_symlinked_ancestor(self) -> None:
+        task = self.root / "task.json"
+        task.write_text(json.dumps(self.task_record("{}")) + "\n")
+        real = self.root / "real"
+        (real / "nested").mkdir(parents=True)
+        alias = self.root / "alias"
+        alias.symlink_to(real, target_is_directory=True)
+        self.output = alias / "nested" / "unit.json"
+
+        result = self.run_cli(task)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("symlink", result.stderr.lower())
+        self.assertFalse((real / "nested" / "unit.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -89,6 +89,132 @@ class HarnessContractTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(json.loads(verified.read_text())["locatorCount"], 1)
 
+    def test_assemble_answer_uses_system_metadata_and_question_order(self) -> None:
+        questions = {
+            "schemaVersion": 1,
+            "questions": [
+                {"id": "Q1", "text": "What is the demo?"},
+                {"id": "Q2", "text": "What is unknown?"},
+            ],
+        }
+        self.questions.write_text(json.dumps(questions) + "\n", encoding="utf-8")
+        spec = json.loads(self.spec.read_text())
+        spec["questions"]["sha256"] = sha256(self.questions)
+        self.spec.write_text(json.dumps(spec) + "\n", encoding="utf-8")
+
+        q1 = self.root / "q1.json"
+        q2 = self.root / "q2.json"
+        base = json.loads(self.answer.read_text())["answers"][0]
+        q1.write_text(json.dumps(base) + "\n", encoding="utf-8")
+        q2.write_text(json.dumps({
+            "questionId": "Q2",
+            "answer": "The live state is not in the snapshot.",
+            "facts": [],
+            "inferences": [],
+            "assumptions": [],
+            "unknowns": [{"id": "U1", "text": "Live state is unknown."}],
+            "locators": [],
+        }) + "\n", encoding="utf-8")
+        client = self.root / "client.json"
+        client.write_text(json.dumps({"name": "second-client", "version": "2"}) + "\n")
+        metrics = self.root / "metrics.json"
+        metrics.write_text(json.dumps({"durationSeconds": 3, "toolOperations": 4}) + "\n")
+
+        assembled = self.outputs / "assembled.json"
+        result = self.run_cli(
+            "assemble-answer", "--experiment", self.spec,
+            "--unit", q2, "--unit", q1,
+            "--client", client, "--metrics", metrics,
+            "--output", assembled,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        answer = json.loads(assembled.read_text())
+        self.assertEqual([item["questionId"] for item in answer["answers"]], ["Q1", "Q2"])
+        self.assertEqual(answer["client"], {"name": "second-client", "version": "2"})
+        self.assertEqual(answer["experimentId"], "fixture")
+        self.assertNotIn("bundleId", answer)
+        self.assertEqual(answer["metrics"]["toolOperations"], 4)
+
+    def test_verify_unit_returns_receipt_without_publishing_an_answer(self) -> None:
+        unit = self.root / "unit.json"
+        unit.write_text(json.dumps(json.loads(self.answer.read_text())["answers"][0]) + "\n")
+        receipt = self.outputs / "unit.verified.json"
+
+        result = self.run_cli(
+            "verify-unit", "--experiment", self.spec, "--unit", unit,
+            "--output", receipt,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        verified = json.loads(receipt.read_text())
+        self.assertEqual(verified["status"], "ok")
+        self.assertEqual(verified["questionId"], "Q1")
+        self.assertEqual(verified["locatorCount"], 1)
+        self.assertEqual(verified["unitSha256"], sha256(unit))
+        self.assertNotIn("answers", verified)
+
+    def test_verify_unit_rejects_non_string_contract_key_without_traceback(self) -> None:
+        harness = importlib.util.module_from_spec(importlib.util.spec_from_file_location("harness", CLI))
+        assert harness.__spec__ is not None and harness.__spec__.loader is not None
+        harness.__spec__.loader.exec_module(harness)
+        unit = json.loads(self.answer.read_text())["answers"][0]
+        unit["facts"][0][1] = "unexpected"
+
+        with self.assertRaises(harness.ContractError):
+            harness.verify_answer_entry(unit, self.snapshot)
+
+    def test_assemble_answer_rejects_non_finite_metrics_without_output(self) -> None:
+        unit = self.root / "unit.json"
+        unit.write_text(json.dumps(json.loads(self.answer.read_text())["answers"][0]) + "\n")
+        client = self.root / "client.json"
+        client.write_text('{"name":"client","version":"1"}\n')
+        metrics = self.root / "metrics.json"
+        metrics.write_text('{"durationSeconds":NaN}\n')
+        output = self.outputs / "must-not-exist-nan.json"
+
+        result = self.run_cli(
+            "assemble-answer", "--experiment", self.spec,
+            "--unit", unit, "--client", client, "--metrics", metrics,
+            "--output", output,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("non-finite", result.stderr.lower())
+        self.assertFalse(output.exists())
+
+    def test_assemble_answer_refuses_incomplete_unit_set_without_output(self) -> None:
+        unit = self.root / "wrong-unit.json"
+        value = json.loads(self.answer.read_text())["answers"][0]
+        value["questionId"] = "Q2"
+        unit.write_text(json.dumps(value) + "\n")
+        client = self.root / "client.json"
+        client.write_text('{"name":"client","version":"1"}\n')
+        metrics = self.root / "metrics.json"
+        metrics.write_text("{}\n")
+        output = self.outputs / "must-not-exist.json"
+
+        result = self.run_cli(
+            "assemble-answer", "--experiment", self.spec,
+            "--unit", unit, "--client", client, "--metrics", metrics,
+            "--output", output,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("question set mismatch", result.stderr.lower())
+        self.assertFalse(output.exists())
+
+    def test_answer_unit_schema_is_the_same_contract_used_by_full_answers(self) -> None:
+        answer_schema = json.loads((ROOT / "contracts" / "answer.schema.json").read_text())
+        unit_schema = json.loads((ROOT / "contracts" / "answer-unit.schema.json").read_text())
+
+        self.assertEqual(answer_schema["$defs"]["answerUnit"], unit_schema["allOf"][0])
+        self.assertEqual(answer_schema["$defs"]["claim"], unit_schema["$defs"]["claim"])
+        self.assertEqual(answer_schema["$defs"]["locator"], unit_schema["$defs"]["locator"])
+        self.assertEqual(
+            answer_schema["properties"]["answers"]["items"],
+            {"$ref": "#/$defs/answerUnit"},
+        )
+
     def test_preflight_rejects_tampered_snapshot(self) -> None:
         (self.snapshot / "Configuration.xml").write_text("tampered\n", encoding="utf-8")
         result = self.run_cli("preflight", "--experiment", self.spec, "--output", self.outputs / "out.json")


### PR DESCRIPTION
## Summary

- add a strict per-question `answer unit` contract and deterministic `verify-unit → assemble-answer → verify-answer` pipeline
- isolate AgentBridge Antigravity's native envelope in a thin fail-closed adapter with no semantic repair
- reject duplicate/non-finite JSON, non-string contract keys, and symlinked path ancestors
- document the completed frozen Antigravity arm and its honest quality boundary

## Frozen Antigravity evidence

Same experiment as PR #6:

- snapshot: `sha256:3357ee63204ff863aac116417927240930084dce0eb7613126ad88cff68a424d`
- questions: `3eba62e70085d74f954968832f5c5d9ab06db0c0da44e83af6bf22651fcbcd90`
- AgentBridge Antigravity CLI: `1.1.15`
- answer: `94e7f3b1c5497156dbb4801c3d61c7ad5f2e93cbd0ef8576242201039d220fbc`
- 7/7 answer units, 27 machine-valid locators, 8 task attempts (one policy-allowed retry)
- post-run preflight: 2581 snapshot files and unchanged content ID
- deterministic reassembly was byte-identical to the verified answer

Independent adjudication using the same frozen 47-item oracle:

| arm | oracle alignment | dangerous false claims |
|---|---:|---:|
| Hermes direct source | 45/47 | 0 |
| Hermes indexed candidate | 44/47 | 0 |
| AgentBridge Antigravity | 31/47 | 0 |

The Antigravity arm proves the technical client boundary but does **not** pass `minimumFactAccuracy = 0.9`. This PR therefore advances #4 and intentionally does not auto-close it.

## Verification

- `python3.9 -m py_compile scripts/harness.py scripts/antigravity_adapter.py tests/test_harness.py tests/test_antigravity_adapter.py`
- `python3.9 -m unittest discover -s tests -v` — 31 passed
- `python3.12 -m py_compile scripts/harness.py scripts/antigravity_adapter.py tests/test_harness.py tests/test_antigravity_adapter.py`
- `python3.12 -m unittest discover -s tests -v` — 31 passed
- all 7 committed/new JSON files parsed
- Markdown local-link audit passed
- frozen Antigravity answer passed the strict parser and `verify-answer`
- `git diff --check`

## Scope and limits

- raw task records, answer units, snapshot and oracle remain in `.local/`
- no universal client SDK, model launcher, parser, index, RAG or third-client abstraction was added
- reproduction requires an authenticated AgentBridge Antigravity runner with the same read-only bundle
- issue #1 still requires human review of the frozen adjudication
- issue #3 still requires the exact target legacy platform or a snapshot produced by it

Advances #4
