### PR TITLE
feat: validate headless request receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ MVP считается полезным не потому, что агент н�
 - [Публичный SDMS review package](experiments/sdms-product-eval-20260825-review/README.md)
 - [Подтверждённая граница совместимости](docs/compatibility.md)
 - [Готовность агентных клиентов](docs/client-readiness.md)
+- [Headless request/response baseline (issue #38)](docs/issue-38-headless-request-response.md)
 - [Knowledge handoff write-cycle экспериментов](docs/write-cycle-knowledge-handoff.md)
 - [Правила работы кодового агента](AGENTS.md)
 

--- a/docs/issue-38-headless-request-response.md
+++ b/docs/issue-38-headless-request-response.md
@@ -1,0 +1,90 @@
+# Headless request/response: narrow baseline (issue #38)
+
+## Decision
+
+The retained headless interface is the smallest proven baseline:
+
+```text
+frozen request → ENTERPRISE /C receipt path → early OnStart probe
+               → exported server call → client receipt + server witness
+               → strict local validator
+```
+
+It is a task preparation pattern, not a permanent 1C API. Every native task still
+uses a read-only canonical source, a named writable prepared copy, and a disposable
+file infobase through `scripts/native_cycle.py run-prepared`.
+
+## Frozen response contract
+
+`scripts/issue38_protocol.py` implements `issue38-v5`.
+
+A request contains fresh UUIDv4 `runId`, `caseId`, and `nonce`, with the fixed
+`operation=serverWitness` and `requiresServer=true`. A successful client receipt
+must record, in order:
+
+1. the exact request identity;
+2. `runtimeStarted`, `probeEntered`, and `serverCallIssued`;
+3. `serverReached` and `caseStarted`;
+4. a server-derived `businessResult`; and
+5. `complete`.
+
+The server-only witness has the same identity, server milestones, result, and
+completion. Both result values must match and must differ from the request nonce.
+
+A typed task failure is a different terminal response: it contains the identity and
+reached client milestones followed by one allowed `failureClass`, optional
+`failureDetail`, and `complete`; a server witness is forbidden for that outcome.
+
+The validator rejects absent, stale, foreign, reordered, duplicate, malformed, or
+post-completion records. It does not convert a runner timeout, an early runtime
+exit, or cleanup failure into an application-level result.
+
+## Normal validation step
+
+After `native_cycle.py` has retained its evidence, validate the request and the
+receipt paths explicitly:
+
+```bash
+python3 scripts/issue38_protocol.py \
+  --request .local/issue38/request.json \
+  --client-receipt .local/runs/native-cycle/<run>/run/evidence/receipt.txt \
+  --server-receipt .local/runs/native-cycle/<run>/run/evidence/receipt.txt.server
+```
+
+The command writes one sorted JSON object to stdout and returns zero only for a
+valid protocol result. A declared successful client receipt without the corresponding
+server witness is rejected.
+
+## Native evidence
+
+On the owner-controlled HOME executor using training 1C `8.5.1.1150`, the A arm
+passed one bounded harmless smoke. The request IDs were fresh; client and server
+receipts contained the same server-generated UUID token; the portable validator
+accepted the pair; the immutable source tree remained unchanged; and no owned 1C
+process remained after cleanup.
+
+Winner validation then proved two distinct outcomes from clean disposable state:
+
+| Scenario | Result |
+|---|---|
+| Server reads `Metadata.Documents.SalesInvoice.Name` | Linked client/server receipts validate as `success` with `SalesInvoice`. |
+| Server raises a fixed task exception | Client receipt validates as typed `taskException`; server witness is absent as required. |
+
+The probes do not call `BankReceipt`, create/post business objects, or modify the
+canonical snapshot, CF, manifest, or live infobase.
+
+## Other arms
+
+- **External EPF `/Execute`: `CONTEXT BLOCKED`.** There is no existing EPF,
+  reproducible authorized export path, or supported runner seam for the exact
+  training runtime. This is not a scored platform failure.
+- **Test Manager/Test Client: `CONTEXT BLOCKED`.** The platform components exist,
+  but there is no task-specific manager algorithm, target/test-client route, or
+  bounded two-client supervisor. This is not a scored platform failure.
+
+## Limits
+
+The two receipts are strong evidence against accidental client-only success, but not
+cryptographic writer attestation against a hostile same-UID process. This mechanism
+proves only the generated task route and does not make a general write API or replace
+business-specific semantic tests.

--- a/scripts/issue38_protocol.py
+++ b/scripts/issue38_protocol.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Portable request/response primitives for Issue #38 transport experiments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import uuid
+from pathlib import Path
+from typing import Final
+
+
+PROTOCOL_VERSION: Final = "issue38-v5"
+OPERATION: Final = "serverWitness"
+_DELIMITER: Final = "###"
+_SAFE_VALUE: Final = re.compile(r"^[A-Za-z0-9._:-]+$")
+_HEADERS: Final = ("protocolVersion", "runId", "caseId", "nonce", "operation")
+_CLIENT_ROWS: Final = (
+    ("runtimeStarted", "true", "Boolean"),
+    ("probeEntered", "true", "Boolean"),
+    ("serverCallIssued", "true", "Boolean"),
+    ("serverReached", "true", "Boolean"),
+    ("caseStarted", "true", "Boolean"),
+)
+_SERVER_ROWS: Final = (
+    ("serverReached", "true", "Boolean"),
+    ("caseStarted", "true", "Boolean"),
+)
+_CLIENT_FAILURE_MILESTONES: Final = {
+    "serverCallFailure": _CLIENT_ROWS[:3],
+    "taskException": _CLIENT_ROWS,
+}
+
+
+class ProtocolError(ValueError):
+    """A receipt cannot prove the frozen Issue #38 protocol result."""
+
+
+def _unique_request_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    request: dict[str, object] = {}
+    for key, value in pairs:
+        if key in request:
+            raise ProtocolError(f"duplicate request key: {key}")
+        request[key] = value
+    return request
+
+
+def new_request() -> dict[str, object]:
+    """Create one fresh, transport-neutral server witness request."""
+    return {
+        "protocolVersion": PROTOCOL_VERSION,
+        "runId": str(uuid.uuid4()),
+        "caseId": str(uuid.uuid4()),
+        "nonce": str(uuid.uuid4()),
+        "operation": OPERATION,
+        "requiresServer": True,
+    }
+
+
+def _decode_receipt(label: str, payload: bytes | None) -> list[tuple[str, str, str]]:
+    if payload is None:
+        raise ProtocolError(f"{label} receipt is absent")
+    try:
+        text = payload.decode("utf-8-sig", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise ProtocolError(f"{label} receipt is not UTF-8") from exc
+    if not text or not text.endswith("\n") or "\r" in text.replace("\r\n", ""):
+        raise ProtocolError(f"{label} receipt has invalid line delimiters")
+    normalized = text.replace("\r\n", "\n")
+    lines = normalized[:-1].split("\n")
+    if not lines or any(not line for line in lines):
+        raise ProtocolError(f"{label} receipt is empty")
+    rows: list[tuple[str, str, str]] = []
+    for line in lines:
+        parts = line.split(_DELIMITER)
+        if len(parts) != 3 or not all(parts):
+            raise ProtocolError(f"{label} receipt has malformed record")
+        if not all(_SAFE_VALUE.fullmatch(part) for part in parts):
+            raise ProtocolError(f"{label} receipt has unsafe record value")
+        rows.append((parts[0], parts[1], parts[2]))
+    return rows
+
+
+def _identity_rows(request: dict[str, object]) -> tuple[tuple[str, str, str], ...]:
+    values: list[tuple[str, str, str]] = []
+    expected = {
+        "protocolVersion": PROTOCOL_VERSION,
+        "operation": OPERATION,
+    }
+    for key in _HEADERS:
+        value = request.get(key)
+        if not isinstance(value, str) or not value or not _SAFE_VALUE.fullmatch(value):
+            raise ProtocolError(f"request has invalid {key}")
+        if key in ("runId", "caseId", "nonce"):
+            try:
+                parsed = uuid.UUID(value)
+            except ValueError as exc:
+                raise ProtocolError(f"request has invalid {key}") from exc
+            if parsed.version != 4:
+                raise ProtocolError(f"request has invalid {key}")
+        if key in expected and value != expected[key]:
+            raise ProtocolError(f"request has unsupported {key}")
+        values.append((key, value, "String"))
+    if request.get("requiresServer") is not True:
+        raise ProtocolError("request must require server")
+    return tuple(values)
+
+
+def _validate_receipt(
+    label: str,
+    payload: bytes | None,
+    identity: tuple[tuple[str, str, str], ...],
+    milestones: tuple[tuple[str, str, str], ...],
+) -> str:
+    rows = _decode_receipt(label, payload)
+    expected_prefix = identity + milestones
+    expected_suffix = (("complete", "true", "Boolean"),)
+    if len(rows) != len(expected_prefix) + 2:
+        raise ProtocolError(f"{label} receipt has unexpected record count")
+    if tuple(rows[:len(expected_prefix)]) != expected_prefix:
+        raise ProtocolError(f"{label} receipt has foreign identity or invalid milestone sequence")
+    result = rows[len(expected_prefix)]
+    if result[0] != "businessResult" or result[2] != "String" or not _SAFE_VALUE.fullmatch(result[1]):
+        raise ProtocolError(f"{label} receipt has invalid business result")
+    if tuple(rows[-1:]) != expected_suffix:
+        raise ProtocolError(f"{label} receipt has invalid completion")
+    return result[1]
+
+
+def validate_terminal(
+    request: dict[str, object], client_receipt: bytes | None, server_receipt: bytes | None,
+) -> dict[str, str]:
+    """Validate either the sole success result or a typed client-side failure."""
+    identity = _identity_rows(request)
+    client_rows = _decode_receipt("client", client_receipt)
+    prefix_size = len(identity)
+    if tuple(client_rows[:prefix_size]) != identity:
+        raise ProtocolError("client receipt has foreign identity")
+    remaining = client_rows[prefix_size:]
+    reached: list[tuple[str, str, str]] = []
+    for milestone in _CLIENT_ROWS:
+        if remaining and remaining[0] == milestone:
+            reached.append(remaining.pop(0))
+        else:
+            break
+    if not remaining:
+        raise ProtocolError("client receipt has no terminal result")
+    if remaining[0][0] == "businessResult":
+        return validate_success(request, client_receipt, server_receipt)
+    if remaining[0][0] != "failureClass" or remaining[0][2] != "String":
+        raise ProtocolError("client receipt has no typed failure class")
+    failure_class = remaining.pop(0)[1]
+    required_milestones = _CLIENT_FAILURE_MILESTONES.get(failure_class)
+    if required_milestones is None:
+        raise ProtocolError("client receipt has unsupported failure class")
+    if tuple(reached) != required_milestones:
+        raise ProtocolError(f"{failure_class} has invalid milestone stage")
+    detail: str | None = None
+    if remaining and remaining[0][0] == "failureDetail" and remaining[0][2] == "String":
+        detail = remaining.pop(0)[1]
+    if remaining != [("complete", "true", "Boolean")]:
+        raise ProtocolError("client receipt has invalid typed failure completion")
+    if server_receipt is not None:
+        raise ProtocolError("server receipt is forbidden on typed client failure")
+    response = {"status": "failure", "failureClass": failure_class}
+    if detail is not None:
+        response["failureDetail"] = detail
+    return response
+
+
+def validate_success(
+    request: dict[str, object], client_receipt: bytes | None, server_receipt: bytes | None,
+) -> dict[str, str]:
+    """Validate both current-run receipts for the sole success protocol outcome."""
+    identity = _identity_rows(request)
+    client_token = _validate_receipt("client", client_receipt, identity, _CLIENT_ROWS)
+    server_token = _validate_receipt("server", server_receipt, identity, _SERVER_ROWS)
+    if client_token != server_token:
+        raise ProtocolError("client and server receipts have different server tokens")
+    if client_token == request["nonce"]:
+        raise ProtocolError("server token must differ from request nonce")
+    return {"status": "success", "serverToken": client_token}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate one frozen request against its client/server receipts."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--request", required=True, type=Path)
+    parser.add_argument("--client-receipt", required=True, type=Path)
+    parser.add_argument("--server-receipt", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        try:
+            request_text = args.request.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise ProtocolError("request is not UTF-8") from exc
+        request = json.loads(request_text, object_pairs_hook=_unique_request_object)
+        if not isinstance(request, dict):
+            raise ProtocolError("request must be a JSON object")
+        client = args.client_receipt.read_bytes()
+        server = args.server_receipt.read_bytes() if args.server_receipt is not None else None
+        response = validate_terminal(request, client, server)
+    except (OSError, json.JSONDecodeError, ProtocolError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(response, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue38_protocol.py
+++ b/tests/test_issue38_protocol.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+import uuid
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "issue38_protocol.py"
+
+
+def load_module() -> object:
+    spec = importlib.util.spec_from_file_location("issue38_protocol_under_test", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError("cannot load Issue 38 protocol module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Issue38ProtocolTests(unittest.TestCase):
+    def test_cli_returns_validated_success_from_bound_receipts(self) -> None:
+        request = _request()
+        client = _receipt([
+            *_headers(request),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("serverCallIssued", "true", "Boolean"),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("businessResult", "server-token-01", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+        server = _receipt([
+            *_headers(request),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("businessResult", "server-token-01", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            request_path = root / "request.json"
+            client_path = root / "client.txt"
+            server_path = root / "server.txt"
+            request_path.write_text(json.dumps(request), encoding="utf-8")
+            client_path.write_bytes(client)
+            server_path.write_bytes(server)
+
+            completed = subprocess.run(
+                [
+                    sys.executable, str(MODULE_PATH),
+                    "--request", str(request_path),
+                    "--client-receipt", str(client_path),
+                    "--server-receipt", str(server_path),
+                ],
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(json.loads(completed.stdout), {
+            "status": "success", "serverToken": "server-token-01",
+        })
+
+
+    def test_cli_returns_nonzero_for_missing_server_receipt_on_success_claim(self) -> None:
+        request = _request()
+        client = _receipt([
+            *_headers(request),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("serverCallIssued", "true", "Boolean"),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("businessResult", "server-token-01", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            request_path = root / "request.json"
+            client_path = root / "client.txt"
+            request_path.write_text(json.dumps(request), encoding="utf-8")
+            client_path.write_bytes(client)
+
+            completed = subprocess.run(
+                [
+                    sys.executable, str(MODULE_PATH),
+                    "--request", str(request_path),
+                    "--client-receipt", str(client_path),
+                ],
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(completed.stdout, "")
+        self.assertIn("server receipt", completed.stderr)
+
+
+    def test_cli_rejects_invalid_utf8_request_without_stdout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            request_path = root / "request.json"
+            client_path = root / "client.txt"
+            request_path.write_bytes(b"\xff\xfe\x00")
+            client_path.write_bytes(b"not-used\n")
+
+            completed = subprocess.run(
+                [
+                    sys.executable, str(MODULE_PATH),
+                    "--request", str(request_path),
+                    "--client-receipt", str(client_path),
+                ],
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(completed.stdout, "")
+        self.assertIn("request is not UTF-8", completed.stderr)
+
+
+    def test_cli_rejects_duplicate_request_identity_keys(self) -> None:
+        request = _request()
+        client = _receipt([
+            *_headers(request),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("serverCallIssued", "true", "Boolean"),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("businessResult", "server-token-01", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+        server = _receipt([
+            *_headers(request),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("businessResult", "server-token-01", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+        duplicate_request = (
+            '{"protocolVersion":"issue38-v5",'
+            '"runId":"00000000-0000-4000-8000-000000000001",'
+            f'"runId":"{request["runId"]}",'
+            f'"caseId":"{request["caseId"]}",'
+            f'"nonce":"{request["nonce"]}",'
+            '"operation":"serverWitness","requiresServer":true}'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            request_path = root / "request.json"
+            client_path = root / "client.txt"
+            server_path = root / "server.txt"
+            request_path.write_text(duplicate_request, encoding="utf-8")
+            client_path.write_bytes(client)
+            server_path.write_bytes(server)
+
+            completed = subprocess.run(
+                [
+                    sys.executable, str(MODULE_PATH),
+                    "--request", str(request_path),
+                    "--client-receipt", str(client_path),
+                    "--server-receipt", str(server_path),
+                ],
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(completed.stdout, "")
+        self.assertIn("duplicate request key", completed.stderr)
+
+
+    def test_new_request_uses_v5_and_three_fresh_uuid4_identifiers(self) -> None:
+        protocol = load_module()
+
+        request = protocol.new_request()
+
+        self.assertEqual(request["protocolVersion"], "issue38-v5")
+        self.assertEqual(request["operation"], "serverWitness")
+        self.assertIs(request["requiresServer"], True)
+        identifiers = [request["runId"], request["caseId"], request["nonce"]]
+        self.assertEqual(len(set(identifiers)), 3)
+        for value in identifiers:
+            parsed = uuid.UUID(value)
+            self.assertEqual(parsed.version, 4)
+
+    def test_validate_success_accepts_current_linked_client_and_server_receipts(self) -> None:
+        protocol = load_module()
+        request = {
+            "protocolVersion": "issue38-v5",
+            "runId": "11111111-1111-4111-8111-111111111111",
+            "caseId": "22222222-2222-4222-8222-222222222222",
+            "nonce": "33333333-3333-4333-8333-333333333333",
+            "operation": "serverWitness",
+            "requiresServer": True,
+        }
+        token = "server-token-01"
+        client = _receipt([
+            ("protocolVersion", "issue38-v5", "String"),
+            ("runId", request["runId"], "String"),
+            ("caseId", request["caseId"], "String"),
+            ("nonce", request["nonce"], "String"),
+            ("operation", "serverWitness", "String"),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("serverCallIssued", "true", "Boolean"),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("businessResult", token, "String"),
+            ("complete", "true", "Boolean"),
+        ])
+        server = _receipt([
+            ("protocolVersion", "issue38-v5", "String"),
+            ("runId", request["runId"], "String"),
+            ("caseId", request["caseId"], "String"),
+            ("nonce", request["nonce"], "String"),
+            ("operation", "serverWitness", "String"),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("businessResult", token, "String"),
+            ("complete", "true", "Boolean"),
+        ])
+
+        result = protocol.validate_success(request, client, server)
+
+        self.assertEqual(result, {"status": "success", "serverToken": token})
+
+    def test_validate_success_rejects_client_only_echo_of_request_nonce(self) -> None:
+        protocol = load_module()
+        request = {
+            "protocolVersion": "issue38-v5", "runId": "11111111-1111-4111-8111-111111111111",
+            "caseId": "22222222-2222-4222-8222-222222222222", "nonce": "33333333-3333-4333-8333-333333333333",
+            "operation": "serverWitness", "requiresServer": True,
+        }
+        client = _receipt([
+            ("protocolVersion", "issue38-v5", "String"), ("runId", request["runId"], "String"),
+            ("caseId", request["caseId"], "String"), ("nonce", request["nonce"], "String"),
+            ("operation", "serverWitness", "String"), ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"), ("serverCallIssued", "true", "Boolean"),
+            ("serverReached", "true", "Boolean"), ("caseStarted", "true", "Boolean"),
+            ("businessResult", request["nonce"], "String"), ("complete", "true", "Boolean"),
+        ])
+
+        with self.assertRaisesRegex(protocol.ProtocolError, "server receipt"):
+            protocol.validate_success(request, client, None)
+
+    def test_validate_success_rejects_foreign_identity_and_extra_record(self) -> None:
+        protocol = load_module()
+        request = {
+            "protocolVersion": "issue38-v5", "runId": "11111111-1111-4111-8111-111111111111",
+            "caseId": "22222222-2222-4222-8222-222222222222", "nonce": "33333333-3333-4333-8333-333333333333",
+            "operation": "serverWitness", "requiresServer": True,
+        }
+        client = _receipt([
+            ("protocolVersion", "issue38-v5", "String"), ("runId", "44444444-4444-4444-8444-444444444444", "String"),
+            ("caseId", request["caseId"], "String"), ("nonce", request["nonce"], "String"),
+            ("operation", "serverWitness", "String"), ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"), ("serverCallIssued", "true", "Boolean"),
+            ("serverReached", "true", "Boolean"), ("caseStarted", "true", "Boolean"),
+            ("businessResult", "server-token-01", "String"), ("complete", "true", "Boolean"),
+            ("extra", "true", "Boolean"),
+        ])
+        server = _receipt([
+            ("protocolVersion", "issue38-v5", "String"), ("runId", request["runId"], "String"),
+            ("caseId", request["caseId"], "String"), ("nonce", request["nonce"], "String"),
+            ("operation", "serverWitness", "String"), ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"), ("businessResult", "server-token-01", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+
+        with self.assertRaisesRegex(protocol.ProtocolError, "client receipt"):
+            protocol.validate_success(request, client, server)
+
+    def test_validate_terminal_returns_explicit_server_call_failure(self) -> None:
+        protocol = load_module()
+        request = _request()
+        client = _receipt([
+            *_headers(request),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("serverCallIssued", "true", "Boolean"),
+            ("failureClass", "serverCallFailure", "String"),
+            ("failureDetail", "call-failed", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+
+        result = protocol.validate_terminal(request, client, None)
+
+        self.assertEqual(result, {
+            "status": "failure", "failureClass": "serverCallFailure", "failureDetail": "call-failed",
+        })
+
+    def test_validate_terminal_rejects_task_exception_before_case_start(self) -> None:
+        protocol = load_module()
+        request = _request()
+        client = _receipt([
+            *_headers(request),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("failureClass", "taskException", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+
+        with self.assertRaisesRegex(protocol.ProtocolError, "taskException"):
+            protocol.validate_terminal(request, client, None)
+
+    def test_validate_terminal_rejects_non_uuid_request_identity(self) -> None:
+        protocol = load_module()
+        request = _request()
+        request["runId"] = "not-a-uuid"
+
+        with self.assertRaisesRegex(protocol.ProtocolError, "runId"):
+            protocol.validate_terminal(request, None, None)
+
+    def test_validate_terminal_accepts_task_exception_after_case_start_without_detail(self) -> None:
+        protocol = load_module()
+        request = _request()
+        client = _receipt([
+            *_headers(request),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("serverCallIssued", "true", "Boolean"),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("failureClass", "taskException", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+
+        self.assertEqual(protocol.validate_terminal(request, client, None), {
+            "status": "failure", "failureClass": "taskException",
+        })
+
+    def test_validate_terminal_rejects_runner_level_timeout_claimed_by_client(self) -> None:
+        protocol = load_module()
+        request = _request()
+        client = _receipt([
+            *_headers(request),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("serverCallIssued", "true", "Boolean"),
+            ("serverReached", "true", "Boolean"),
+            ("caseStarted", "true", "Boolean"),
+            ("failureClass", "timeoutAfterCaseStart", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+
+        with self.assertRaisesRegex(protocol.ProtocolError, "unsupported failure class"):
+            protocol.validate_terminal(request, client, None)
+
+    def test_validate_terminal_rejects_server_receipt_on_typed_client_failure(self) -> None:
+        protocol = load_module()
+        request = _request()
+        client = _receipt([
+            *_headers(request),
+            ("runtimeStarted", "true", "Boolean"),
+            ("probeEntered", "true", "Boolean"),
+            ("serverCallIssued", "true", "Boolean"),
+            ("failureClass", "serverCallFailure", "String"),
+            ("complete", "true", "Boolean"),
+        ])
+
+        with self.assertRaisesRegex(protocol.ProtocolError, "server receipt"):
+            protocol.validate_terminal(request, client, b"not-a-receipt\r\n")
+
+    def test_validate_terminal_rejects_unicode_line_separator(self) -> None:
+        protocol = load_module()
+        request = _request()
+        payload = ("###".join(("protocolVersion", "issue38-v5", "String")) + "\u0085").encode("utf-8")
+
+        with self.assertRaisesRegex(protocol.ProtocolError, "line delimiters"):
+            protocol.validate_terminal(request, payload, None)
+
+
+def _request() -> dict[str, object]:
+    return {
+        "protocolVersion": "issue38-v5", "runId": "11111111-1111-4111-8111-111111111111",
+        "caseId": "22222222-2222-4222-8222-222222222222", "nonce": "33333333-3333-4333-8333-333333333333",
+        "operation": "serverWitness", "requiresServer": True,
+    }
+
+
+def _headers(request: dict[str, object]) -> list[tuple[str, str, str]]:
+    return [
+        ("protocolVersion", str(request["protocolVersion"]), "String"),
+        ("runId", str(request["runId"]), "String"),
+        ("caseId", str(request["caseId"]), "String"),
+        ("nonce", str(request["nonce"]), "String"),
+        ("operation", str(request["operation"]), "String"),
+    ]
+
+
+def _receipt(rows: list[tuple[str, str, str]]) -> bytes:
+    return ("\r\n".join("###".join(row) for row in rows) + "\r\n").encode("utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the minimal reusable result of #38, on top of the open #35 baseline.

## What
- validates frozen `issue38-v5` client/server receipts with fresh UUIDv4 identity;
- provides a small CLI that emits one JSON result only for valid evidence;
- rejects missing server witness for success, malformed/stale/foreign records, invalid UTF-8, and duplicate request keys;
- documents the proven `OnStart → server call → linked receipts` baseline.

## Native evidence
The owner-controlled HOME executor ran the harmless A smoke plus a metadata-read success and controlled typed-failure validation. B and C are context-blocked, not scored failures. No canonical CF/snapshot/manifest/live IB was changed.

## Verification
- `python3 -m unittest tests.test_issue38_protocol -v` (15 passed)
- `python3 -m unittest tests.test_native_cycle -v` (46 passed)
- `python3 -m py_compile scripts/issue38_protocol.py`
- `git diff --check`
- dual review `dr-4755d8c60b8a445f`, with concrete input-validation findings fixed and follow-up `dr-d19e7c88239f49c3` = `NO_GAP_FOUND`.

Open/unmerged for owner decision.