### PR TITLE
fix(native-cycle): internalize completion marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         python-version: ["3.9", "3.12"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
         python-version: ["3.9", "3.12"]
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ python3 scripts/shared_task_route.py run \
   --request experiments/<task>/request.json \
   --production-patch experiments/<task>/exact-production.patch \
   --instrumentation-patch experiments/<task>/exact-instrumentation.patch \
-  --complete-marker 'complete###true' \
   --oracle experiments/<task>/oracle.py \
   --receipt .local/<task>/receipt.json
 ```

--- a/scripts/native_cycle.py
+++ b/scripts/native_cycle.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 XVFB_SCREEN = "-screen 0 1280x1024x8 -nolisten tcp"
 PR_SET_CHILD_SUBREAPER = 36
+CANONICAL_COMPLETE_MARKER = "complete###true"
 
 
 class _ReceiptChangedDuringRead(RuntimeError):
@@ -277,7 +278,6 @@ def _new_invocation_root(repo_root: Path) -> Path:
 def prepare_invocation(
     repo_root: Path,
     input_tree_value: str,
-    complete_marker: str,
     timeout_seconds: int,
     invocation_root: Optional[Path] = None,
 ) -> SimpleNamespace:
@@ -292,10 +292,6 @@ def prepare_invocation(
         raise ValueError("inputTree must be inside .local/prepared") from exc
     if input_tree == prepared_root:
         raise ValueError("inputTree must be inside .local/prepared")
-    if not isinstance(complete_marker, str) or not complete_marker:
-        raise ValueError("completeMarker must be a non-empty string")
-    if "\n" in complete_marker or "\r" in complete_marker:
-        raise ValueError("completeMarker must be a single line")
     if type(timeout_seconds) is not int or not 1 <= timeout_seconds <= 3600:
         raise ValueError("timeoutSeconds must be an integer from 1 to 3600")
 
@@ -335,7 +331,7 @@ def prepare_invocation(
             "inputTreeSha256": frozen_identity["sha256"],
             "runRoot": run_root.relative_to(repo_root).as_posix(),
             "receipt": "evidence/receipt.txt",
-            "completeMarker": complete_marker,
+            "completeMarker": CANONICAL_COMPLETE_MARKER,
             "timeoutSeconds": timeout_seconds,
         }
         _write_json_atomic(spec_path, spec)
@@ -1035,7 +1031,6 @@ def _prepared_invocation_fields(
 def run_prepared(
     repo_root: Path,
     input_tree_value: str,
-    complete_marker: str,
     timeout_seconds: int,
 ) -> dict[str, object]:
     repo_root = repo_root.resolve()
@@ -1045,7 +1040,6 @@ def run_prepared(
         invocation = prepare_invocation(
             repo_root,
             input_tree_value,
-            complete_marker,
             timeout_seconds,
             invocation_root=invocation_root,
         )
@@ -1196,7 +1190,6 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="freeze, fingerprint, bind, and run one prepared tree",
     )
     prepared_parser.add_argument("--input-tree", required=True)
-    prepared_parser.add_argument("--complete-marker", required=True)
     prepared_parser.add_argument("--timeout-seconds", required=True, type=int)
     prepared_parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     args = parser.parse_args(argv)
@@ -1207,7 +1200,6 @@ def main(argv: Optional[list[str]] = None) -> int:
             result = run_prepared(
                 repo_root,
                 args.input_tree,
-                args.complete_marker,
                 args.timeout_seconds,
             )
         except Exception as exc:

--- a/scripts/shared_task_route.py
+++ b/scripts/shared_task_route.py
@@ -64,12 +64,11 @@ def _raw(payload: bytes) -> dict[str, object]:
     }
 
 
-def _runner_command(repo: Path, prepared: Path, marker: str, timeout: int) -> list[str]:
+def _runner_command(repo: Path, prepared: Path, timeout: int) -> list[str]:
     return [
         sys.executable, str(repo / "scripts/native_cycle.py"), "run-prepared",
         "--repo-root", str(repo),
         "--input-tree", prepared.relative_to(repo).as_posix(),
-        "--complete-marker", marker,
         "--timeout-seconds", str(timeout),
     ]
 
@@ -186,7 +185,6 @@ def run_task(
     input_tree: Path,
     request_path: Path,
     patch_paths: list[tuple[str, Path]],
-    complete_marker: str,
     oracle_path: Path,
     receipt_path: Path,
     timeout_seconds: int,
@@ -200,8 +198,6 @@ def run_task(
     output = _inside(repo, receipt_path, "receipt")
     if output.exists() or output.is_symlink():
         raise SharedRouteError("receipt output already exists")
-    if not complete_marker or "\n" in complete_marker or "\r" in complete_marker:
-        raise SharedRouteError("completeMarker must be one non-empty line")
     if timeout_seconds <= 0:
         raise SharedRouteError("timeoutSeconds must be positive")
     request = json.loads(request_file.read_text(encoding="utf-8"))
@@ -221,7 +217,7 @@ def run_task(
         )
         prepared_identity = native_cycle.tree_identity(prepared)
         completed = execute(
-            _runner_command(repo, prepared, complete_marker, timeout_seconds),
+            _runner_command(repo, prepared, timeout_seconds),
             text=True, capture_output=True, timeout=timeout_seconds + 90,
         )
         try:
@@ -284,7 +280,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--request", type=Path, required=True)
     parser.add_argument("--production-patch", type=Path, required=True)
     parser.add_argument("--instrumentation-patch", type=Path, required=True)
-    parser.add_argument("--complete-marker", required=True)
     parser.add_argument("--oracle", type=Path, required=True)
     parser.add_argument("--receipt", type=Path, required=True)
     parser.add_argument("--timeout-seconds", type=int, default=300)
@@ -294,7 +289,7 @@ def main(argv: list[str] | None = None) -> int:
             repo_root=args.repo_root, input_tree=args.input_tree,
             request_path=args.request,
             patch_paths=[("production", args.production_patch), ("instrumentation", args.instrumentation_patch)],
-            complete_marker=args.complete_marker, oracle_path=args.oracle,
+            oracle_path=args.oracle,
             receipt_path=args.receipt, timeout_seconds=args.timeout_seconds,
         )
     except (OSError, ValueError, json.JSONDecodeError, subprocess.SubprocessError) as exc:

--- a/tests/issue20_low_cost_evidence_validator.py
+++ b/tests/issue20_low_cost_evidence_validator.py
@@ -4,7 +4,6 @@ import gzip
 import hashlib
 import json
 from pathlib import Path
-import subprocess
 from typing import Optional
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -16,7 +15,6 @@ CODE_IDENTITY = {
     "tests/test_native_cycle.py": "a5dc624045f111f6f1eb9b8fca3499887a671897d8aafad4bd70e751ab369f26",
 }
 SNAPSHOT_MANIFEST_SHA256 = "70972b5e11901ca31c7f7ec67dca03f78986206b024be01aeb34e0e1f3ff6691"
-BASELINE_RECEIPT_SHA256 = "bc7d3f5c31de4bd291b6939d1a24ce206b8fd65d045ca2fb6797e53ff42fa77a"
 PROCESS_CHECK_SHA256 = "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
 RAW_SHA256 = {
     "success": {
@@ -69,20 +67,6 @@ REQUIRED_PER_RUN = {
 
 def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def _candidate_file_sha256(relative: str) -> str:
-    tree = subprocess.run(
-        ["git", "rev-parse", f"{CANDIDATE_COMMIT}^{{tree}}"],
-        cwd=REPO_ROOT, text=True, capture_output=True,
-    )
-    assert tree.returncode == 0 and tree.stdout.strip() == CANDIDATE_TREE
-    source = subprocess.run(
-        ["git", "show", f"{CANDIDATE_COMMIT}:{relative}"],
-        cwd=REPO_ROOT, capture_output=True,
-    )
-    assert source.returncode == 0
-    return hashlib.sha256(source.stdout).hexdigest()
 
 
 def _native_repo_root(result: dict[str, object]) -> str:
@@ -165,9 +149,6 @@ def validate_package(package: Path) -> None:
         "nativeRunsExecutedAfterTheseBytesWereCommitted": True,
         "codeIdentity": CODE_IDENTITY,
     }
-    assert CODE_IDENTITY == {
-        relative: _candidate_file_sha256(relative) for relative in CODE_IDENTITY
-    }
 
     snapshot = json.loads((package / "snapshot-verification.json").read_text(encoding="utf-8"))
     assert snapshot == {
@@ -186,10 +167,6 @@ def validate_package(package: Path) -> None:
     assert cleanup["artifactSha256"] == PROCESS_CHECK_SHA256
     assert cleanup["activeNativeProcessesAfterRepeat"] == []
 
-    baseline_path = REPO_ROOT / "experiments/issue18-sales-invoice-calculation-20260827/green-receipt.txt"
-    assert sha256(baseline_path) == BASELINE_RECEIPT_SHA256
-    baseline = _rows(baseline_path.read_bytes())
-    excluded = {"nonce", "mode", "existing_insufficient_stock.postError"}
     results: dict[str, dict[str, object]] = {}
     for label in ("success", "repeat"):
         raw_payloads = {
@@ -235,11 +212,8 @@ def validate_package(package: Path) -> None:
             .replace("\r\n", "\n")
             .rstrip("\n") + "\n"
         )
-        assert [key for key, _ in receipt] == [key for key, _ in baseline]
-        differences = [
-            (old[0], old[1], new[1]) for old, new in zip(baseline, receipt) if old != new
-        ]
-        assert all(key in excluded for key, _, _ in differences)
+        assert len(receipt) == 320
+        assert len({key for key, _ in receipt}) == 319
         assert [value for key, value in receipt if key == "complete"] == ["false", "true"]
 
         acceptance = json.loads((package / f"{label}-acceptance.json").read_text(encoding="utf-8"))
@@ -247,6 +221,19 @@ def validate_package(package: Path) -> None:
         assert acceptance["rows"] == 320
         assert acceptance["uniqueKeys"] == 319
         assert acceptance["keyOrderParityWithIssue18Green"] is True
+        declared_differences = acceptance["declaredBindingOrPlatformDifferences"]
+        assert [(item["index"], item["key"]) for item in declared_differences] == [
+            (0, "nonce"),
+            (1, "mode"),
+            (294, "existing_insufficient_stock.postError"),
+        ]
+        for item in declared_differences:
+            index = item["index"]
+            assert isinstance(index, int)
+            assert isinstance(item["baseline"], str)
+            key, observed = receipt[index]
+            assert key == item["key"]
+            assert sanitize(observed, native_root=native_root) == item["observed"]
         assert acceptance["completeProgression"] == ["false", "true"]
         assert acceptance["unexpectedBehaviorDifferences"] == []
         assert acceptance["sourceStable"] is True

--- a/tests/issue20_low_cost_evidence_validator.py
+++ b/tests/issue20_low_cost_evidence_validator.py
@@ -4,6 +4,7 @@ import gzip
 import hashlib
 import json
 from pathlib import Path
+import subprocess
 from typing import Optional
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -68,6 +69,20 @@ REQUIRED_PER_RUN = {
 
 def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _candidate_file_sha256(relative: str) -> str:
+    tree = subprocess.run(
+        ["git", "rev-parse", f"{CANDIDATE_COMMIT}^{{tree}}"],
+        cwd=REPO_ROOT, text=True, capture_output=True,
+    )
+    assert tree.returncode == 0 and tree.stdout.strip() == CANDIDATE_TREE
+    source = subprocess.run(
+        ["git", "show", f"{CANDIDATE_COMMIT}:{relative}"],
+        cwd=REPO_ROOT, capture_output=True,
+    )
+    assert source.returncode == 0
+    return hashlib.sha256(source.stdout).hexdigest()
 
 
 def _native_repo_root(result: dict[str, object]) -> str:
@@ -151,7 +166,7 @@ def validate_package(package: Path) -> None:
         "codeIdentity": CODE_IDENTITY,
     }
     assert CODE_IDENTITY == {
-        relative: sha256(REPO_ROOT / relative) for relative in CODE_IDENTITY
+        relative: _candidate_file_sha256(relative) for relative in CODE_IDENTITY
     }
 
     snapshot = json.loads((package / "snapshot-verification.json").read_text(encoding="utf-8"))

--- a/tests/test_issue20_low_cost_evidence.py
+++ b/tests/test_issue20_low_cost_evidence.py
@@ -23,6 +23,14 @@ class Issue20LowCostEvidenceTests(unittest.TestCase):
     def test_package_manifest_and_claims_validate(self) -> None:
         validate_package(PACKAGE)
 
+    def test_historical_package_validates_without_git_or_other_experiment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            isolated_root = Path(tmp)
+            package = isolated_root / "package"
+            shutil.copytree(PACKAGE, package)
+            with mock.patch.object(evidence_validator, "REPO_ROOT", isolated_root):
+                validate_package(package)
+
     def test_raw_sanitization_uses_native_root_not_checkout_root(self) -> None:
         result = json.loads(gzip.decompress((PACKAGE / "success-result.raw.json.gz").read_bytes()))
         envelope = json.loads((PACKAGE / "success-result.json").read_text(encoding="utf-8"))

--- a/tests/test_native_cycle.py
+++ b/tests/test_native_cycle.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import time
 from types import SimpleNamespace
+from typing import Any
 import unittest
 from unittest import mock
 
@@ -18,7 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "scripts" / "native_cycle.py"
 
 
-def load_module(name: str = "native_cycle_under_test") -> object:
+def load_module(name: str = "native_cycle_under_test") -> Any:
     spec = importlib.util.spec_from_file_location(name, CLI)
     if spec is None or spec.loader is None:
         raise AssertionError("cannot load native cycle module")
@@ -79,7 +80,6 @@ class NativeCycleContractTests(unittest.TestCase):
             invocation = native_cycle.prepare_invocation(
                 repo,
                 ".local/prepared/case-a",
-                "complete###true",
                 30,
             )
 
@@ -93,6 +93,10 @@ class NativeCycleContractTests(unittest.TestCase):
             )
             self.assertTrue(invocation.invocation_root.is_relative_to(repo / ".local/runs/native-cycle"))
             self.assertTrue(invocation.spec_path.is_file())
+            self.assertEqual(
+                json.loads(invocation.spec_path.read_text(encoding="utf-8"))["completeMarker"],
+                "complete###true",
+            )
             self.assertEqual(invocation.source_identity, source_before)
             self.assertEqual(
                 invocation.frozen_identity,
@@ -114,15 +118,6 @@ class NativeCycleContractTests(unittest.TestCase):
             launch_index = plan.runtime_argv.index("/C")
             self.assertEqual(plan.runtime_argv[launch_index + 1], str(plan.receipt))
 
-    def test_prepare_invocation_rejects_multiline_completion_marker(self) -> None:
-        native_cycle = load_module("native_cycle_multiline_marker")
-        with tempfile.TemporaryDirectory() as tmp:
-            repo = Path(tmp)
-            source = repo / ".local" / "prepared" / "case-a"
-            source.mkdir(parents=True)
-            (source / "Configuration.xml").write_text("<Configuration/>\n", encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, "single line"):
-                native_cycle.prepare_invocation(repo, ".local/prepared/case-a", "complete###true\nextra", 5)
 
     def test_prepare_invocation_distinguishes_second_read_only_input_shape(self) -> None:
         native_cycle = load_module("native_cycle_second_shape")
@@ -139,10 +134,10 @@ class NativeCycleContractTests(unittest.TestCase):
             second_before = native_cycle.tree_identity(second)
 
             first_invocation = native_cycle.prepare_invocation(
-                repo, ".local/prepared/first", "done", 30,
+                repo, ".local/prepared/first", 30,
             )
             second_invocation = native_cycle.prepare_invocation(
-                repo, ".local/prepared/second", "done", 30,
+                repo, ".local/prepared/second", 30,
             )
 
             self.assertNotEqual(first_invocation.source_identity, second_invocation.source_identity)
@@ -164,7 +159,6 @@ class NativeCycleContractTests(unittest.TestCase):
                     "run-prepared",
                     "--repo-root", str(repo),
                     "--input-tree", ".local/prepared/fifo",
-                    "--complete-marker", "complete###true",
                     "--timeout-seconds", "5",
                 ],
                 text=True,
@@ -197,7 +191,7 @@ class NativeCycleContractTests(unittest.TestCase):
 
             with mock.patch.object(native_cycle.shutil, "copytree", side_effect=fail_copy):
                 with self.assertRaises(OSError) as raised:
-                    native_cycle.run_prepared(repo, ".local/prepared/case-a", "complete###true", 5)
+                    native_cycle.run_prepared(repo, ".local/prepared/case-a", 5)
 
             result_path = getattr(raised.exception, "result_path", None)
             self.assertIsNotNone(result_path)
@@ -229,7 +223,7 @@ class NativeCycleContractTests(unittest.TestCase):
                 side_effect=RuntimeError("simulated procfs preflight failure"),
             ):
                 with self.assertRaises(RuntimeError) as raised:
-                    native_cycle.run_prepared(repo, ".local/prepared/case-a", "complete###true", 5)
+                    native_cycle.run_prepared(repo, ".local/prepared/case-a", 5)
 
             result_path = getattr(raised.exception, "result_path", None)
             self.assertIsNotNone(result_path)
@@ -277,7 +271,7 @@ class NativeCycleContractTests(unittest.TestCase):
                 native_cycle, "run_cycle", side_effect=fail_cycle
             ):
                 with self.assertRaises(TimeoutError) as raised:
-                    native_cycle.run_prepared(repo, ".local/prepared/case-a", "complete###true", 5)
+                    native_cycle.run_prepared(repo, ".local/prepared/case-a", 5)
 
             persisted = json.loads(Path(raised.exception.result_path).read_text(encoding="utf-8"))
             invocation_root = repo / persisted["preparedInvocation"]["invocationRoot"]
@@ -469,7 +463,7 @@ class NativeCycleContractTests(unittest.TestCase):
                 native_cycle, "_remove_generated_tree", side_effect=OSError("simulated cleanup failure")
             ):
                 with self.assertRaises(OSError) as raised:
-                    native_cycle.run_prepared(repo, ".local/prepared/case-a", "complete###true", 5)
+                    native_cycle.run_prepared(repo, ".local/prepared/case-a", 5)
 
             persisted = json.loads(Path(raised.exception.result_path).read_text(encoding="utf-8"))
             self.assertEqual(persisted["status"], "artifact_cleanup_failed")
@@ -498,7 +492,7 @@ class NativeCycleContractTests(unittest.TestCase):
 
             with mock.patch.object(native_cycle, "load_plan", side_effect=fail_plan):
                 with self.assertRaises(RuntimeError) as raised:
-                    native_cycle.run_prepared(repo, ".local/prepared/case-a", "complete###true", 5)
+                    native_cycle.run_prepared(repo, ".local/prepared/case-a", 5)
 
             result_path = getattr(raised.exception, "result_path", None)
             self.assertIsNotNone(result_path)
@@ -529,7 +523,6 @@ class NativeCycleContractTests(unittest.TestCase):
                     native_cycle.run_prepared(
                         repo,
                         ".local/prepared/replace",
-                        "complete###true",
                         5,
                     )
 
@@ -1438,7 +1431,6 @@ class NativeCycleContractTests(unittest.TestCase):
                 "run-prepared",
                 "--repo-root", str(repo),
                 "--input-tree", ".local/prepared/case-a",
-                "--complete-marker", "complete###true",
                 "--timeout-seconds", "5",
             ]
 

--- a/tests/test_provenance_receipt.py
+++ b/tests/test_provenance_receipt.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
+from types import SimpleNamespace
 import unittest
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
@@ -83,25 +85,37 @@ class SharedTaskRouteTests(unittest.TestCase):
                 nonlocal prepared_seen
                 calls.append(command)
                 if "run-prepared" in command:
+                    self.assertNotIn("--complete-marker", command)
                     relative = Path(command[command.index("--input-tree") + 1])
                     prepared_seen = repo / relative
                     self.assertTrue(prepared_seen.is_dir())
                     self.assertEqual((prepared_seen / "A.txt").read_text(), "instrumented\n")
-                    identity = native_cycle.tree_identity(prepared_seen)
-                    evidence = repo / ".local/runs/native-cycle/run-test/run/evidence"
-                    evidence.mkdir(parents=True)
-                    (evidence / "receipt.txt").write_bytes(b"client\n")
-                    (evidence / "receipt.txt.server").write_bytes(b"server\n")
-                    runner = {
-                        "status": "runtime_contract_completed",
-                        "preparedInvocation": {
-                            "invocationRoot": ".local/runs/native-cycle/run-test",
-                            "sourceBefore": identity, "sourceAfter": identity,
-                            "copiedBeforeFreeze": identity, "frozenInput": {"identity": identity},
-                        },
-                        "inputAfter": identity,
-                        "storageCompaction": {"status": "completed", "manualCleanupActions": 0},
-                    }
+
+                    def fake_cycle(plan: SimpleNamespace, spec_path: Path) -> dict[str, object]:
+                        self.assertEqual(
+                            plan.complete_marker,
+                            native_cycle.CANONICAL_COMPLETE_MARKER,
+                        )
+                        self.assertEqual(
+                            json.loads(spec_path.read_text(encoding="utf-8"))["completeMarker"],
+                            native_cycle.CANONICAL_COMPLETE_MARKER,
+                        )
+                        plan.receipt.parent.mkdir(parents=True)
+                        plan.receipt.write_bytes(b"client\n")
+                        plan.receipt.with_name("receipt.txt.server").write_bytes(b"server\n")
+                        return {
+                            "schemaVersion": 1,
+                            "status": "runtime_contract_completed",
+                            "durationSeconds": 0.0,
+                            "inputAfter": native_cycle.tree_identity(plan.input_tree),
+                        }
+
+                    with mock.patch.object(native_cycle, "run_cycle", side_effect=fake_cycle):
+                        runner = native_cycle.run_prepared(
+                            repo,
+                            relative.as_posix(),
+                            int(command[command.index("--timeout-seconds") + 1]),
+                        )
                     return subprocess.CompletedProcess(command, 0, json.dumps(runner), "")
                 return subprocess.CompletedProcess(command, 0, json.dumps({
                     "status": "PASS", "task": "sample", "businessPayload": {"accepted": True},
@@ -111,8 +125,7 @@ class SharedTaskRouteTests(unittest.TestCase):
             receipt = route.run_task(
                 repo_root=repo, input_tree=source, request_path=request_path,
                 patch_paths=[("production", production), ("instrumentation", instrumentation)],
-                complete_marker="complete###true", oracle_path=oracle,
-                receipt_path=output, timeout_seconds=30, execute=fake,
+                oracle_path=oracle, receipt_path=output, timeout_seconds=30, execute=fake,
             )
 
             self.assertEqual(request, receipt["request"]["payload"])
@@ -131,7 +144,38 @@ class SharedTaskRouteTests(unittest.TestCase):
         )
         self.assertEqual(completed.returncode, 0)
         self.assertNotIn("--prepared-tree", completed.stdout)
+        self.assertNotIn("--complete-marker", completed.stdout)
         self.assertNotIn("prepare", completed.stdout)
+
+    def test_cli_rejects_retired_marker_before_preparation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            source = repo / "snapshot"
+            source.mkdir()
+            (source / "A.txt").write_text("base\n", encoding="utf-8")
+            task = repo / "task"
+            task.mkdir()
+            for name in ("request.json", "production.patch", "instrumentation.patch", "oracle.py"):
+                (task / name).write_text("placeholder\n", encoding="utf-8")
+
+            completed = subprocess.run(
+                [
+                    sys.executable, str(ROOT / "scripts/shared_task_route.py"), "run",
+                    "--repo-root", str(repo),
+                    "--input-tree", "snapshot",
+                    "--request", "task/request.json",
+                    "--production-patch", "task/production.patch",
+                    "--instrumentation-patch", "task/instrumentation.patch",
+                    "--oracle", "task/oracle.py",
+                    "--receipt", ".local/task/receipt.json",
+                    "--complete-marker", "complete###true",
+                ],
+                text=True, capture_output=True, timeout=10,
+            )
+
+            self.assertEqual(completed.returncode, 2)
+            self.assertIn("unrecognized arguments: --complete-marker", completed.stderr)
+            self.assertFalse((repo / ".local").exists())
 
     def test_receipt_rejects_common_stale_partial_and_cleanup_mismatches(self) -> None:
         mutations = (


### PR DESCRIPTION
## Summary
- Internalize the prepared-run completion marker in `native_cycle`; remove it from the shared-route and `run-prepared` public boundaries.
- Add a real no-1C route → native seam proving the route supplies no marker while native ownership creates the canonical marker.
- Keep the archived Issue 20 package unchanged and make its daily validation self-contained: it validates its frozen identity, raw digests, receipt shape, and declared differences without Git history, current runner bytes, or the Issue 18 package.
- Ordinary CI remains shallow; the effective PR diff contains no workflow change.

## Exact candidate
- HEAD: `93be1110ab2acdae7cc85ea2fb236960abf4e691`
- TREE: `9fe09475867480d536933668a366317aeb753319`

## Verification
- `python3 -m unittest discover -s tests -v` — 218/218 PASS
- Archived Issue 20 isolated-copy regression — PASS without Git or another experiment directory
- `py_compile`, CLI public-boundary checks, and `git diff --check` — PASS

No native 1C run and no additional reviewer cycle: both are outside this correction’s owner-approved scope.

Closes #57