### PR TITLE
feat(issue58): inspect bounded document context

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,14 @@ GitHub, не task validator.
 
 ## Контекст одного документа
 
-Когда exact `Document.<Name>` уже найден обычным `rg`, одна read-only команда возвращает
-небольшую доказанную карту его непосредственной поверхности:
+Когда exact `Document.<Name>` уже найден обычным `rg`, команда принимает только сериализованный
+`SnapshotRef`, ранее выданный `project_target.py open`, и повторно проверяет его через тот же
+retained-target admission boundary:
 
 ```bash
+python3 scripts/project_target.py open > .local/snapshot-ref.json
 python3 scripts/object_context.py inspect \
-  --snapshot .local/targets/jettr-1.0.3.1/snapshot \
+  --snapshot-ref .local/snapshot-ref.json \
   --object Document.SupplierInvoice \
   --focus Warehouse
 ```

--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ contract, request, exact production patch, exact instrumentation patch и mainta
 Исторические packages не переписываются, а candidate commit/tree и CI остаются ответственностью
 GitHub, не task validator.
 
+## Контекст одного документа
+
+Когда exact `Document.<Name>` уже найден обычным `rg`, одна read-only команда возвращает
+небольшую доказанную карту его непосредственной поверхности:
+
+```bash
+python3 scripts/object_context.py inspect \
+  --snapshot .local/targets/jettr-1.0.3.1/snapshot \
+  --object Document.SupplierInvoice \
+  --focus Warehouse
+```
+
+JSON содержит descriptor, реквизиты и табличные части, принадлежащие XML/BSL/form/template
+артефакты, короткий outline процедур с line locators, `DataPath`/события/команды форм и
+одношаговые конфигурационные связи. `Document` — единственный поддержанный тип v1; прочие
+canonical metadata identifiers возвращают `unsupported`. Полные BSL/XML, рекурсивный граф,
+семантические выводы и постоянный index не строятся. Все списки детерминированно ограничены:
+`truncated` и `diagnostics` обязательны, когда часть ответа не помещается.
+
 ## Цель MVP
 
 Кодовый агент в Linux-окружении получает снимок конфигурации 1С и может:

--- a/scripts/object_context.py
+++ b/scripts/object_context.py
@@ -245,9 +245,18 @@ def parse_outline(
                             "locator": locator(relative, number),
                         }
                     )
-    key = lambda item: (item["name"], item["locator"]["path"], item["locator"]["startLine"])
+    def outline_key(item: dict[str, Any]) -> tuple[int, str, str, int]:
+        path = item["locator"]["path"]
+        if path.endswith("/Ext/ObjectModule.bsl"):
+            priority = 0
+        elif path.endswith("/Ext/ManagerModule.bsl"):
+            priority = 1
+        else:
+            priority = 2
+        return priority, path, item["name"], item["locator"]["startLine"]
+
     relation_key = lambda item: (item["target"], item["locator"]["path"], item["locator"]["startLine"])
-    return sorted(outline, key=key), sorted({json.dumps(item, sort_keys=True): item for item in candidates}.values(), key=relation_key)
+    return sorted(outline, key=outline_key), sorted({json.dumps(item, sort_keys=True): item for item in candidates}.values(), key=relation_key)
 
 
 def parse_forms(snapshot: Path, artifacts: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/scripts/object_context.py
+++ b/scripts/object_context.py
@@ -46,8 +46,13 @@ def deep_text(element: ET.Element | None) -> str:
     return "".join(element.itertext()).strip() if element is not None else ""
 
 
+def first_present(*elements: ET.Element | None) -> ET.Element | None:
+    return next((element for element in elements if element is not None), None)
+
+
 def object_properties(element: ET.Element) -> ET.Element:
-    return first_child(element, "Properties") or element
+    properties = first_child(element, "Properties")
+    return properties if properties is not None else element
 
 
 def object_name(element: ET.Element) -> str:
@@ -158,6 +163,7 @@ def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[di
         return result
 
     attributes = named_items("Attribute")
+    child_objects_or_empty = child_objects if child_objects is not None else ET.Element("empty")
     tabular_sections: list[dict[str, Any]] = []
     if child_objects is not None:
         for section in children(child_objects, "TabularSection"):
@@ -165,7 +171,9 @@ def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[di
             if not section_name:
                 continue
             section_attributes: list[dict[str, Any]] = []
-            section_attributes_node = first_child(section, "ChildObjects") or first_child(section, "Attributes")
+            section_attributes_node = first_present(
+                first_child(section, "ChildObjects"), first_child(section, "Attributes")
+            )
             if section_attributes_node is not None:
                 for child in children(section_attributes_node, "Attribute"):
                     child_name = object_name(child)
@@ -188,8 +196,16 @@ def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[di
         "descriptor": {"name": name, "kind": "Document", "locator": locator(relative, find_line(lines, f"<Name>{name}</Name>"))},
         "attributes": sorted(attributes, key=lambda value: value["name"]),
         "tabularSections": sorted(tabular_sections, key=lambda value: value["name"]),
-        "forms": sorted(object_name(item) for item in children(child_objects or ET.Element("empty"), "Form") if object_name(item)),
-        "templates": sorted(object_name(item) for item in children(child_objects or ET.Element("empty"), "Template") if object_name(item)),
+        "forms": sorted(
+            object_name(item)
+            for item in children(child_objects_or_empty, "Form")
+            if object_name(item)
+        ),
+        "templates": sorted(
+            object_name(item)
+            for item in children(child_objects_or_empty, "Template")
+            if object_name(item)
+        ),
     }
     return metadata, collect_owned_artifacts(snapshot, name)
 

--- a/scripts/object_context.py
+++ b/scripts/object_context.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Return a bounded, read-only context map for one 1C Document snapshot object."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any, Iterable
+import xml.etree.ElementTree as ET
+
+
+DEFAULT_LIMIT = 24
+DEFAULT_BYTE_LIMIT = 32 * 1024
+NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+OUTLINE = re.compile(
+    r"^\s*(Procedure|Function)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*?)\)\s*(Export)?\s*$",
+    re.IGNORECASE,
+)
+END_OUTLINE = re.compile(r"^\s*End(Procedure|Function)\s*;?\s*$", re.IGNORECASE)
+METADATA_TOKEN = re.compile(
+    r"\b(AccumulationRegister|BusinessProcess|Catalog|ChartOfCharacteristicTypes|"
+    r"Document|ExchangePlan|InformationRegister|Report|Role|Subsystem)\.([A-Za-z_][A-Za-z0-9_]*)\b"
+)
+
+
+def local_name(element: ET.Element) -> str:
+    return element.tag.rsplit("}", 1)[-1]
+
+
+def children(element: ET.Element, name: str) -> list[ET.Element]:
+    return [child for child in element if local_name(child) == name]
+
+
+def first_child(element: ET.Element, name: str) -> ET.Element | None:
+    matches = children(element, name)
+    return matches[0] if matches else None
+
+
+def element_text(element: ET.Element | None) -> str:
+    return (element.text or "").strip() if element is not None else ""
+
+
+def text_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8-sig", errors="strict").splitlines()
+
+
+def locator(relative: Path, line: int, end_line: int | None = None) -> dict[str, Any]:
+    return {
+        "path": relative.as_posix(),
+        "startLine": line,
+        "endLine": line if end_line is None else end_line,
+    }
+
+
+def find_line(lines: list[str], needle: str, occurrence: int = 1) -> int:
+    seen = 0
+    for number, line in enumerate(lines, start=1):
+        if needle in line:
+            seen += 1
+            if seen == occurrence:
+                return number
+    return 1
+
+
+def read_regular(root: Path, relative: Path) -> tuple[Path, list[str]]:
+    path = root / relative
+    if path.is_symlink() or not path.is_file():
+        raise InputBlocked("snapshot_invalid", f"required artifact is not a regular file: {relative.as_posix()}")
+    return path, text_lines(path)
+
+
+class InputBlocked(RuntimeError):
+    def __init__(self, reason_code: str, message: str):
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def block(reason_code: str, message: str) -> dict[str, Any]:
+    return {"schemaVersion": 1, "status": "blocked", "reasonCode": reason_code, "message": message}
+
+
+def artifact(relative: Path, kind: str) -> dict[str, Any]:
+    return {"kind": kind, "locator": locator(relative, 1)}
+
+
+def collect_owned_artifacts(snapshot: Path, name: str) -> list[dict[str, Any]]:
+    owner = Path("Documents") / name
+    package = snapshot / owner
+    if package.is_symlink() or not package.is_dir():
+        raise InputBlocked("object_not_found", f"Document.{name} has no object package")
+    result: list[dict[str, Any]] = []
+    for path in sorted(package.rglob("*")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        relative = path.relative_to(snapshot)
+        parts = relative.parts
+        if relative.suffix.lower() == ".bsl":
+            kind = "bslModule"
+        elif "Forms" in parts and relative.name == "Form.xml":
+            kind = "form"
+        elif "Forms" in parts and relative.suffix.lower() == ".xml":
+            kind = "formDescriptor"
+        elif "Templates" in parts:
+            kind = "template"
+        else:
+            kind = "ownedArtifact"
+        result.append(artifact(relative, kind))
+    return result
+
+
+def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    relative = Path("Documents") / f"{name}.xml"
+    path, lines = read_regular(snapshot, relative)
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        raise InputBlocked("snapshot_invalid", f"cannot parse descriptor: {relative.as_posix()}") from exc
+    document = next((item for item in root.iter() if local_name(item) == "Document"), None)
+    properties = first_child(document, "Properties") if document is not None else None
+    if document is None or properties is None or element_text(first_child(properties, "Name")) != name:
+        raise InputBlocked("snapshot_invalid", f"descriptor identity mismatch: {relative.as_posix()}")
+
+    def named_items(parent_name: str, item_name: str) -> list[dict[str, Any]]:
+        parent = first_child(properties, parent_name)
+        result: list[dict[str, Any]] = []
+        if parent is None:
+            return result
+        for item in children(parent, item_name):
+            item_name_value = element_text(first_child(item, "Name"))
+            if not item_name_value:
+                continue
+            result.append(
+                {
+                    "name": item_name_value,
+                    "type": element_text(first_child(item, "Type")) or None,
+                    "locator": locator(relative, find_line(lines, f"<Name>{item_name_value}</Name>")),
+                }
+            )
+        return result
+
+    attributes = named_items("Attributes", "Attribute")
+    tabular_sections: list[dict[str, Any]] = []
+    sections = first_child(properties, "TabularSections")
+    if sections is not None:
+        for section in children(sections, "TabularSection"):
+            section_name = element_text(first_child(section, "Name"))
+            if not section_name:
+                continue
+            section_attributes: list[dict[str, Any]] = []
+            section_attributes_node = first_child(section, "Attributes")
+            if section_attributes_node is not None:
+                for child in children(section_attributes_node, "Attribute"):
+                    child_name = element_text(first_child(child, "Name"))
+                    if child_name:
+                        section_attributes.append(
+                            {
+                                "name": child_name,
+                                "type": element_text(first_child(child, "Type")) or None,
+                                "locator": locator(relative, find_line(lines, f"<Name>{child_name}</Name>")),
+                            }
+                        )
+            tabular_sections.append(
+                {
+                    "name": section_name,
+                    "attributes": sorted(section_attributes, key=lambda value: value["name"]),
+                    "locator": locator(relative, find_line(lines, f"<Name>{section_name}</Name>")),
+                }
+            )
+    metadata = {
+        "descriptor": {"name": name, "kind": "Document", "locator": locator(relative, find_line(lines, f"<Name>{name}</Name>"))},
+        "attributes": sorted(attributes, key=lambda value: value["name"]),
+        "tabularSections": sorted(tabular_sections, key=lambda value: value["name"]),
+        "forms": sorted(element_text(item) for item in children(first_child(properties, "Forms") or ET.Element("empty"), "Form") if element_text(item)),
+        "templates": sorted(element_text(item) for item in children(first_child(properties, "Templates") or ET.Element("empty"), "Template") if element_text(item)),
+    }
+    return metadata, collect_owned_artifacts(snapshot, name)
+
+
+def parse_outline(
+    snapshot: Path, artifacts: Iterable[dict[str, Any]], focus_terms: Iterable[str]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    outline: list[dict[str, Any]] = []
+    candidates: list[dict[str, Any]] = []
+    focus = tuple(term.casefold() for term in focus_terms)
+    for item in artifacts:
+        if item["kind"] != "bslModule":
+            continue
+        relative = Path(item["locator"]["path"])
+        _, lines = read_regular(snapshot, relative)
+        active: tuple[str, str, int, bool] | None = None
+        for number, line in enumerate(lines, start=1):
+            match = OUTLINE.match(line)
+            if match:
+                active = (match.group(1).lower(), match.group(2), number, bool(match.group(4)))
+            elif active is not None and END_OUTLINE.match(line):
+                kind, name, start, exported = active
+                outline.append(
+                    {"name": name, "kind": kind, "exported": exported, "locator": locator(relative, start, number)}
+                )
+                active = None
+            for relation_match in METADATA_TOKEN.finditer(line):
+                token = f"{relation_match.group(1)}.{relation_match.group(2)}"
+                if token != "Document." + relative.parts[1] and (
+                    not focus or any(term in line.casefold() for term in focus)
+                ):
+                    candidates.append(
+                        {
+                            "kind": "lexical",
+                            "target": token,
+                            "state": "candidate",
+                            "locator": locator(relative, number),
+                        }
+                    )
+    key = lambda item: (item["name"], item["locator"]["path"], item["locator"]["startLine"])
+    relation_key = lambda item: (item["target"], item["locator"]["path"], item["locator"]["startLine"])
+    return sorted(outline, key=key), sorted({json.dumps(item, sort_keys=True): item for item in candidates}.values(), key=relation_key)
+
+
+def parse_forms(snapshot: Path, artifacts: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    forms: list[dict[str, Any]] = []
+    for item in artifacts:
+        if item["kind"] != "form":
+            continue
+        relative = Path(item["locator"]["path"])
+        path, lines = read_regular(snapshot, relative)
+        try:
+            root = ET.parse(path).getroot()
+        except ET.ParseError as exc:
+            raise InputBlocked("snapshot_invalid", f"cannot parse form: {relative.as_posix()}") from exc
+        data_paths = []
+        events = []
+        commands = []
+        for node in root.iter():
+            node_kind = local_name(node)
+            value = element_text(node)
+            if node_kind == "DataPath" and value:
+                data_paths.append({"value": value, "locator": locator(relative, find_line(lines, value))})
+            elif node_kind == "Event" and value:
+                events.append({"name": node.get("name") or value, "handler": value, "locator": locator(relative, find_line(lines, value))})
+            elif node_kind in {"CommandName", "Action"} and value:
+                commands.append({"name": value, "locator": locator(relative, find_line(lines, value))})
+        forms.append(
+            {
+                "name": relative.parts[3],
+                "locator": locator(relative, 1),
+                "dataPaths": sorted(data_paths, key=lambda value: (value["value"], value["locator"]["startLine"])),
+                "events": sorted(events, key=lambda value: (value["name"], value["handler"])),
+                "commands": sorted(commands, key=lambda value: value["name"]),
+            }
+        )
+    return sorted(forms, key=lambda value: value["name"])
+
+
+def confirmed_relations(snapshot: Path, object_name: str) -> list[dict[str, Any]]:
+    token = f"Document.{object_name}"
+    roots = {
+        "Configuration.xml": "configuration",
+        "Roles": "role",
+        "EventSubscriptions": "eventSubscription",
+        "Subsystems": "subsystem",
+        "FunctionalOptions": "functionalOption",
+    }
+    result: list[dict[str, Any]] = []
+    for raw_root, kind in roots.items():
+        source = snapshot / raw_root
+        paths = [source] if source.is_file() else sorted(source.rglob("*.xml")) if source.is_dir() and not source.is_symlink() else []
+        for path in paths:
+            if path.is_symlink() or not path.is_file():
+                continue
+            relative = path.relative_to(snapshot)
+            for number, line in enumerate(text_lines(path), start=1):
+                if token in line or (kind == "configuration" and f">{object_name}<" in line):
+                    result.append({"kind": kind, "target": token, "state": "confirmed", "locator": locator(relative, number)})
+    unique = {json.dumps(item, sort_keys=True): item for item in result}
+    return sorted(unique.values(), key=lambda value: (value["kind"], value["locator"]["path"], value["locator"]["startLine"]))
+
+
+def cap(values: list[Any], limit: int, diagnostics: list[str], label: str) -> list[Any]:
+    if len(values) > limit:
+        diagnostics.append(label)
+        return values[:limit]
+    return values
+
+
+def apply_limits(payload: dict[str, Any], limit: int) -> None:
+    diagnostics: list[str] = []
+    payload["metadata"]["attributes"] = cap(payload["metadata"]["attributes"], limit, diagnostics, "metadata.attributes")
+    payload["metadata"]["tabularSections"] = cap(payload["metadata"]["tabularSections"], limit, diagnostics, "metadata.tabularSections")
+    payload["artifacts"] = cap(payload["artifacts"], limit, diagnostics, "artifacts")
+    payload["bsl"]["outline"] = cap(payload["bsl"]["outline"], limit, diagnostics, "bsl.outline")
+    payload["relations"]["confirmed"] = cap(payload["relations"]["confirmed"], limit, diagnostics, "relations.confirmed")
+    payload["relations"]["candidates"] = cap(payload["relations"]["candidates"], limit, diagnostics, "relations.candidates")
+    for form in payload["forms"]:
+        for key in ("dataPaths", "events", "commands"):
+            form[key] = cap(form[key], limit, diagnostics, f"forms.{key}")
+    payload["forms"] = cap(payload["forms"], limit, diagnostics, "forms")
+    payload["truncated"] = bool(diagnostics)
+    payload["diagnostics"] = sorted(set(diagnostics))
+
+
+def encode(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True) + "\n"
+
+
+def inspect(snapshot: Path, canonical_name: str, limit: int, focus_terms: Iterable[str] = ()) -> dict[str, Any]:
+    if not snapshot.exists() or snapshot.is_symlink() or not snapshot.is_dir():
+        raise InputBlocked("snapshot_unavailable", "snapshot must be an existing regular directory")
+    if not canonical_name.startswith("Document."):
+        if "." in canonical_name and all(NAME.fullmatch(part) for part in canonical_name.split(".", 1)):
+            return {"schemaVersion": 1, "status": "unsupported", "object": {"canonicalName": canonical_name}}
+        raise InputBlocked("invalid_object", "object must be canonical Document.<Name>")
+    name = canonical_name.removeprefix("Document.")
+    if not NAME.fullmatch(name):
+        raise InputBlocked("invalid_object", "object must be canonical Document.<Name>")
+    descriptor = snapshot / "Documents" / f"{name}.xml"
+    if descriptor.is_symlink() or not descriptor.is_file():
+        raise InputBlocked("object_not_found", f"Document.{name} is absent from snapshot")
+    metadata, artifacts = parse_descriptor(snapshot, name)
+    normalized_focus = tuple(sorted({term.strip() for term in focus_terms if term.strip()}))
+    outline, candidates = parse_outline(snapshot, artifacts, normalized_focus)
+    payload: dict[str, Any] = {
+        "schemaVersion": 1,
+        "status": "ready",
+        "object": {"canonicalName": canonical_name, "kind": "Document"},
+        "focusTerms": list(normalized_focus),
+        "metadata": metadata,
+        "artifacts": artifacts,
+        "bsl": {"outline": outline},
+        "forms": parse_forms(snapshot, artifacts),
+        "relations": {"confirmed": confirmed_relations(snapshot, name), "candidates": candidates},
+        "unknown": ["BSL lexical candidates are not semantic links; inspect their cited source before using them."],
+        "unsupported": ["Non-Document metadata objects", "recursive relation graph", "BSL bodies and full AST"],
+        "truncated": False,
+        "diagnostics": [],
+    }
+    apply_limits(payload, limit)
+    while len(encode(payload).encode("utf-8")) > DEFAULT_BYTE_LIMIT and limit > 1:
+        limit = max(1, limit // 2)
+        apply_limits(payload, limit)
+        payload["diagnostics"] = sorted(set(payload["diagnostics"] + ["byteLimit"]))
+        payload["truncated"] = True
+    if len(encode(payload).encode("utf-8")) > DEFAULT_BYTE_LIMIT:
+        raise InputBlocked("result_too_large", "minimum bounded result exceeds 32 KiB")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    inspect_parser = commands.add_parser("inspect", help="inspect one canonical Document object")
+    inspect_parser.add_argument("--snapshot", required=True, type=Path)
+    inspect_parser.add_argument("--object", required=True)
+    inspect_parser.add_argument("--focus", action="append", default=[], help="optional term for BSL lexical candidates")
+    inspect_parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    args = parser.parse_args(argv)
+    if args.limit < 1 or args.limit > 64:
+        print(encode(block("invalid_limit", "limit must be between 1 and 64")), end="")
+        return 2
+    try:
+        result = inspect(args.snapshot, args.object, args.limit, args.focus)
+    except InputBlocked as exc:
+        print(encode(block(exc.reason_code, str(exc))), end="")
+        return 2
+    print(encode(result), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/object_context.py
+++ b/scripts/object_context.py
@@ -10,15 +10,17 @@ import sys
 from typing import Any, Iterable
 import xml.etree.ElementTree as ET
 
+from target_admission import TargetBlocked, admit_target, load_contract, paths, snapshot_ref, unique_object
+
 
 DEFAULT_LIMIT = 24
 DEFAULT_BYTE_LIMIT = 32 * 1024
 NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 OUTLINE = re.compile(
-    r"^\s*(Procedure|Function)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*?)\)\s*(Export)?\s*$",
+    r"^\s*(Procedure|Function|Процедура|Функция)\s+([^\W\d]\w*)\s*\((.*?)\)\s*(Export|Экспорт)?\s*$",
     re.IGNORECASE,
 )
-END_OUTLINE = re.compile(r"^\s*End(Procedure|Function)\s*;?\s*$", re.IGNORECASE)
+END_OUTLINE = re.compile(r"^\s*(End(Procedure|Function)|Конец(Процедуры|Функции))\s*;?\s*$", re.IGNORECASE)
 METADATA_TOKEN = re.compile(
     r"\b(AccumulationRegister|BusinessProcess|Catalog|ChartOfCharacteristicTypes|"
     r"Document|ExchangePlan|InformationRegister|Report|Role|Subsystem)\.([A-Za-z_][A-Za-z0-9_]*)\b"
@@ -85,6 +87,17 @@ def find_line(lines: list[str], needle: str, occurrence: int = 1) -> int:
     return 1
 
 
+class LineLocators:
+    def __init__(self, lines: list[str]) -> None:
+        self.lines = lines
+        self.occurrences: dict[str, int] = {}
+
+    def locator(self, relative: Path, needle: str) -> dict[str, Any]:
+        occurrence = self.occurrences.get(needle, 0) + 1
+        self.occurrences[needle] = occurrence
+        return locator(relative, find_line(self.lines, needle, occurrence))
+
+
 def read_regular(root: Path, relative: Path) -> tuple[Path, list[str]]:
     path = root / relative
     if path.is_symlink() or not path.is_file():
@@ -100,6 +113,22 @@ class InputBlocked(RuntimeError):
 
 def block(reason_code: str, message: str) -> dict[str, Any]:
     return {"schemaVersion": 1, "status": "blocked", "reasonCode": reason_code, "message": message}
+
+
+def resolve_snapshot_ref(repo_root: Path, reference_path: Path) -> Path:
+    if reference_path.is_symlink() or not reference_path.is_file():
+        raise InputBlocked("snapshot_ref_invalid", "SnapshotRef must be a regular JSON file")
+    try:
+        reference = json.loads(reference_path.read_text(encoding="utf-8"), object_pairs_hook=unique_object)
+        contract, _ = load_contract(repo_root)
+        action = reference.get("action") if isinstance(reference, dict) else None
+        if action not in {"materialized", "reused"} or reference != snapshot_ref(contract, action):
+            raise ValueError("SnapshotRef does not match the project target contract")
+        _, target, snapshot, manifest, binding = paths(repo_root, contract)
+        admit_target(target, snapshot, manifest, binding, contract)
+        return snapshot
+    except (OSError, ValueError, TypeError, TargetBlocked) as exc:
+        raise InputBlocked("snapshot_ref_invalid", "SnapshotRef failed authoritative target admission") from exc
 
 
 def artifact(relative: Path, kind: str) -> dict[str, Any]:
@@ -123,6 +152,8 @@ def collect_owned_artifacts(snapshot: Path, name: str) -> list[dict[str, Any]]:
             kind = "form"
         elif "Forms" in parts and relative.suffix.lower() == ".xml":
             kind = "formDescriptor"
+        elif "Commands" in parts:
+            kind = "command"
         elif "Templates" in parts:
             kind = "template"
         else:
@@ -134,6 +165,7 @@ def collect_owned_artifacts(snapshot: Path, name: str) -> list[dict[str, Any]]:
 def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     relative = Path("Documents") / f"{name}.xml"
     path, lines = read_regular(snapshot, relative)
+    locations = LineLocators(lines)
     try:
         root = ET.parse(path).getroot()
     except ET.ParseError as exc:
@@ -157,7 +189,7 @@ def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[di
                 {
                     "name": item_name_value,
                     "type": object_type(item),
-                    "locator": locator(relative, find_line(lines, f"<Name>{item_name_value}</Name>")),
+                    "locator": locations.locator(relative, f"<Name>{item_name_value}</Name>"),
                 }
             )
         return result
@@ -182,18 +214,18 @@ def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[di
                             {
                                 "name": child_name,
                                 "type": object_type(child),
-                                "locator": locator(relative, find_line(lines, f"<Name>{child_name}</Name>")),
+                                "locator": locations.locator(relative, f"<Name>{child_name}</Name>"),
                             }
                         )
             tabular_sections.append(
                 {
                     "name": section_name,
                     "attributes": sorted(section_attributes, key=lambda value: value["name"]),
-                    "locator": locator(relative, find_line(lines, f"<Name>{section_name}</Name>")),
+                    "locator": locations.locator(relative, f"<Name>{section_name}</Name>"),
                 }
             )
     metadata = {
-        "descriptor": {"name": name, "kind": "Document", "locator": locator(relative, find_line(lines, f"<Name>{name}</Name>"))},
+        "descriptor": {"name": name, "kind": "Document", "locator": locations.locator(relative, f"<Name>{name}</Name>")},
         "attributes": sorted(attributes, key=lambda value: value["name"]),
         "tabularSections": sorted(tabular_sections, key=lambda value: value["name"]),
         "forms": sorted(
@@ -266,6 +298,7 @@ def parse_forms(snapshot: Path, artifacts: Iterable[dict[str, Any]]) -> list[dic
             continue
         relative = Path(item["locator"]["path"])
         path, lines = read_regular(snapshot, relative)
+        locations = LineLocators(lines)
         try:
             root = ET.parse(path).getroot()
         except ET.ParseError as exc:
@@ -277,11 +310,11 @@ def parse_forms(snapshot: Path, artifacts: Iterable[dict[str, Any]]) -> list[dic
             node_kind = local_name(node)
             value = element_text(node)
             if node_kind == "DataPath" and value:
-                data_paths.append({"value": value, "locator": locator(relative, find_line(lines, value))})
+                data_paths.append({"value": value, "locator": locations.locator(relative, value)})
             elif node_kind == "Event" and value:
-                events.append({"name": node.get("name") or value, "handler": value, "locator": locator(relative, find_line(lines, value))})
+                events.append({"name": node.get("name") or value, "handler": value, "locator": locations.locator(relative, value)})
             elif node_kind in {"CommandName", "Action"} and value:
-                commands.append({"name": value, "locator": locator(relative, find_line(lines, value))})
+                commands.append({"name": value, "locator": locations.locator(relative, value)})
         forms.append(
             {
                 "name": relative.parts[3],
@@ -296,24 +329,57 @@ def parse_forms(snapshot: Path, artifacts: Iterable[dict[str, Any]]) -> list[dic
 
 def confirmed_relations(snapshot: Path, object_name: str) -> list[dict[str, Any]]:
     token = f"Document.{object_name}"
-    roots = {
+    sources = {
         "Configuration.xml": "configuration",
         "Roles": "role",
         "EventSubscriptions": "eventSubscription",
         "Subsystems": "subsystem",
         "FunctionalOptions": "functionalOption",
     }
+
+    def relation_position(kind: str, path: tuple[str, ...], value: str) -> bool:
+        if kind == "configuration":
+            return path[-3:] == ("Configuration", "ChildObjects", "Document") and value == object_name
+        if kind == "role":
+            return path[-3:] == ("Rights", "object", "name") and value == token
+        if kind == "eventSubscription":
+            return path[-1:] == ("Source",) and value == token
+        if kind == "subsystem":
+            return path[-4:] == ("Subsystem", "Properties", "Content", "Item") and value == token
+        if kind == "functionalOption":
+            return path[-1:] == ("Content",) and value == token
+        return False
+
+    def nodes(element: ET.Element, parent: tuple[str, ...] = ()) -> Iterable[tuple[ET.Element, tuple[str, ...]]]:
+        path = parent + (local_name(element),)
+        yield element, path
+        for child in element:
+            yield from nodes(child, path)
+
     result: list[dict[str, Any]] = []
-    for raw_root, kind in roots.items():
+    for raw_root, kind in sources.items():
         source = snapshot / raw_root
         paths = [source] if source.is_file() else sorted(source.rglob("*.xml")) if source.is_dir() and not source.is_symlink() else []
         for path in paths:
             if path.is_symlink() or not path.is_file():
                 continue
             relative = path.relative_to(snapshot)
-            for number, line in enumerate(text_lines(path), start=1):
-                if token in line or (kind == "configuration" and f">{object_name}<" in line):
-                    result.append({"kind": kind, "target": token, "state": "confirmed", "locator": locator(relative, number)})
+            try:
+                root = ET.parse(path).getroot()
+            except ET.ParseError as exc:
+                raise InputBlocked("snapshot_invalid", f"cannot parse relation source: {relative.as_posix()}") from exc
+            locations = LineLocators(text_lines(path))
+            for node, position in nodes(root):
+                value = element_text(node)
+                if relation_position(kind, position, value):
+                    result.append(
+                        {
+                            "kind": kind,
+                            "target": token,
+                            "state": "confirmed",
+                            "locator": locations.locator(relative, value),
+                        }
+                    )
     unique = {json.dumps(item, sort_keys=True): item for item in result}
     return sorted(unique.values(), key=lambda value: (value["kind"], value["locator"]["path"], value["locator"]["startLine"]))
 
@@ -388,10 +454,11 @@ def inspect(snapshot: Path, canonical_name: str, limit: int, focus_terms: Iterab
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     commands = parser.add_subparsers(dest="command", required=True)
-    inspect_parser = commands.add_parser("inspect", help="inspect one canonical Document object")
-    inspect_parser.add_argument("--snapshot", required=True, type=Path)
+    inspect_parser = commands.add_parser("inspect", help="inspect one canonical Document object", allow_abbrev=False)
+    inspect_parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    inspect_parser.add_argument("--snapshot-ref", required=True, type=Path)
     inspect_parser.add_argument("--object", required=True)
     inspect_parser.add_argument("--focus", action="append", default=[], help="optional term for BSL lexical candidates")
     inspect_parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
@@ -400,7 +467,8 @@ def main(argv: list[str] | None = None) -> int:
         print(encode(block("invalid_limit", "limit must be between 1 and 64")), end="")
         return 2
     try:
-        result = inspect(args.snapshot, args.object, args.limit, args.focus)
+        snapshot = resolve_snapshot_ref(args.repo_root.resolve(), args.snapshot_ref)
+        result = inspect(snapshot, args.object, args.limit, args.focus)
     except InputBlocked as exc:
         print(encode(block(exc.reason_code, str(exc))), end="")
         return 2

--- a/scripts/object_context.py
+++ b/scripts/object_context.py
@@ -42,6 +42,22 @@ def element_text(element: ET.Element | None) -> str:
     return (element.text or "").strip() if element is not None else ""
 
 
+def deep_text(element: ET.Element | None) -> str:
+    return "".join(element.itertext()).strip() if element is not None else ""
+
+
+def object_properties(element: ET.Element) -> ET.Element:
+    return first_child(element, "Properties") or element
+
+
+def object_name(element: ET.Element) -> str:
+    return element_text(first_child(object_properties(element), "Name")) or element_text(element)
+
+
+def object_type(element: ET.Element) -> str | None:
+    return deep_text(first_child(object_properties(element), "Type")) or None
+
+
 def text_lines(path: Path) -> list[str]:
     return path.read_text(encoding="utf-8-sig", errors="strict").splitlines()
 
@@ -122,42 +138,42 @@ def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[di
     if document is None or properties is None or element_text(first_child(properties, "Name")) != name:
         raise InputBlocked("snapshot_invalid", f"descriptor identity mismatch: {relative.as_posix()}")
 
-    def named_items(parent_name: str, item_name: str) -> list[dict[str, Any]]:
-        parent = first_child(properties, parent_name)
+    child_objects = first_child(document, "ChildObjects")
+
+    def named_items(item_name: str) -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = []
-        if parent is None:
+        if child_objects is None:
             return result
-        for item in children(parent, item_name):
-            item_name_value = element_text(first_child(item, "Name"))
+        for item in children(child_objects, item_name):
+            item_name_value = object_name(item)
             if not item_name_value:
                 continue
             result.append(
                 {
                     "name": item_name_value,
-                    "type": element_text(first_child(item, "Type")) or None,
+                    "type": object_type(item),
                     "locator": locator(relative, find_line(lines, f"<Name>{item_name_value}</Name>")),
                 }
             )
         return result
 
-    attributes = named_items("Attributes", "Attribute")
+    attributes = named_items("Attribute")
     tabular_sections: list[dict[str, Any]] = []
-    sections = first_child(properties, "TabularSections")
-    if sections is not None:
-        for section in children(sections, "TabularSection"):
-            section_name = element_text(first_child(section, "Name"))
+    if child_objects is not None:
+        for section in children(child_objects, "TabularSection"):
+            section_name = object_name(section)
             if not section_name:
                 continue
             section_attributes: list[dict[str, Any]] = []
-            section_attributes_node = first_child(section, "Attributes")
+            section_attributes_node = first_child(section, "ChildObjects") or first_child(section, "Attributes")
             if section_attributes_node is not None:
                 for child in children(section_attributes_node, "Attribute"):
-                    child_name = element_text(first_child(child, "Name"))
+                    child_name = object_name(child)
                     if child_name:
                         section_attributes.append(
                             {
                                 "name": child_name,
-                                "type": element_text(first_child(child, "Type")) or None,
+                                "type": object_type(child),
                                 "locator": locator(relative, find_line(lines, f"<Name>{child_name}</Name>")),
                             }
                         )
@@ -172,8 +188,8 @@ def parse_descriptor(snapshot: Path, name: str) -> tuple[dict[str, Any], list[di
         "descriptor": {"name": name, "kind": "Document", "locator": locator(relative, find_line(lines, f"<Name>{name}</Name>"))},
         "attributes": sorted(attributes, key=lambda value: value["name"]),
         "tabularSections": sorted(tabular_sections, key=lambda value: value["name"]),
-        "forms": sorted(element_text(item) for item in children(first_child(properties, "Forms") or ET.Element("empty"), "Form") if element_text(item)),
-        "templates": sorted(element_text(item) for item in children(first_child(properties, "Templates") or ET.Element("empty"), "Template") if element_text(item)),
+        "forms": sorted(object_name(item) for item in children(child_objects or ET.Element("empty"), "Form") if object_name(item)),
+        "templates": sorted(object_name(item) for item in children(child_objects or ET.Element("empty"), "Template") if object_name(item)),
     }
     return metadata, collect_owned_artifacts(snapshot, name)
 

--- a/tests/test_object_context.py
+++ b/tests/test_object_context.py
@@ -105,7 +105,7 @@ class ObjectContextTests(unittest.TestCase):
             self.assertEqual([item["name"] for item in payload["metadata"]["tabularSections"]], ["Goods"])
             self.assertEqual(
                 [item["name"] for item in payload["bsl"]["outline"]],
-                ["CurrentWarehouse", "Initialize", "OnOpen", "Posting", "WarehouseOnChange"],
+                ["CurrentWarehouse", "Posting", "Initialize", "OnOpen", "WarehouseOnChange"],
             )
             self.assertEqual(
                 [item["value"] for item in payload["forms"][0]["dataPaths"]],

--- a/tests/test_object_context.py
+++ b/tests/test_object_context.py
@@ -34,15 +34,13 @@ def write_document_snapshot(root: Path, name: str = "GoodsReceipt") -> Path:
   <Document>
     <Properties>
       <Name>{name}</Name>
-      <Attributes>
-        <Attribute><Name>Warehouse</Name><Type>CatalogRef.Warehouses</Type></Attribute>
-      </Attributes>
-      <TabularSections>
-        <TabularSection><Name>Goods</Name><Attributes><Attribute><Name>Product</Name><Type>CatalogRef.Products</Type></Attribute></Attributes></TabularSection>
-      </TabularSections>
-      <Forms><Form>DocumentForm</Form></Forms>
-      <Templates><Template>PrintForm</Template></Templates>
     </Properties>
+    <ChildObjects>
+      <Attribute><Name>Warehouse</Name><Type>CatalogRef.Warehouses</Type></Attribute>
+      <TabularSection><Name>Goods</Name><Attributes><Attribute><Name>Product</Name><Type>CatalogRef.Products</Type></Attribute></Attributes></TabularSection>
+      <Form><Name>DocumentForm</Name></Form>
+      <Template><Name>PrintForm</Name></Template>
+    </ChildObjects>
   </Document>
 </MetaDataObject>
 """,

--- a/tests/test_object_context.py
+++ b/tests/test_object_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 import subprocess
@@ -9,11 +10,38 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "scripts" / "object_context.py"
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import object_context
+import target_admission
 
 
 def run_inspect(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    options = dict(zip(arguments[::2], arguments[1::2]))
+    try:
+        payload = object_context.inspect(
+            root,
+            str(options["--object"]),
+            int(options.get("--limit") or object_context.DEFAULT_LIMIT),
+            [value for flag, value in zip(arguments, arguments[1:]) if flag == "--focus"],
+        )
+    except object_context.InputBlocked as exc:
+        return subprocess.CompletedProcess([], 2, object_context.encode(object_context.block(exc.reason_code, str(exc))), "")
+    return subprocess.CompletedProcess([], 0, object_context.encode(payload), "")
+
+
+def run_ref_inspect(repo: Path, snapshot_ref: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [sys.executable, str(CLI), "inspect", "--snapshot", str(root), *arguments],
+        [
+            sys.executable,
+            str(CLI),
+            "inspect",
+            "--repo-root",
+            str(repo),
+            "--snapshot-ref",
+            str(snapshot_ref),
+            *arguments,
+        ],
         text=True,
         capture_output=True,
         check=False,
@@ -23,10 +51,11 @@ def run_inspect(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]
 def write_document_snapshot(root: Path, name: str = "GoodsReceipt") -> Path:
     (root / "Documents" / name / "Ext").mkdir(parents=True)
     (root / "Documents" / name / "Forms" / "DocumentForm" / "Ext" / "Form").mkdir(parents=True)
+    (root / "Documents" / name / "Commands" / "Print" / "Ext").mkdir(parents=True)
     (root / "Roles" / "Purchases" / "Ext").mkdir(parents=True)
     (root / "EventSubscriptions").mkdir(parents=True)
     (root / "Configuration.xml").write_text(
-        f"<Configuration><Documents><Document>{name}</Document></Documents></Configuration>\n",
+        f"<MetaDataObject><Configuration><ChildObjects><Document>{name}</Document></ChildObjects></Configuration></MetaDataObject>\n",
         encoding="utf-8",
     )
     (root / "Documents" / f"{name}.xml").write_text(
@@ -77,13 +106,48 @@ EndFunction
         "Procedure OnOpen(Cancel)\nEndProcedure\nProcedure WarehouseOnChange(Item)\nEndProcedure\n",
         encoding="utf-8",
     )
+    (root / "Documents" / name / "Commands" / "Print" / "Ext" / "Command.xml").write_text(
+        "<Command><Properties><Name>Print</Name></Properties></Command>\n", encoding="utf-8"
+    )
     (root / "Roles" / "Purchases" / "Ext" / "Rights.xml").write_text(
-        f"<Rights><name>Document.{name}</name></Rights>\n", encoding="utf-8"
+        f"<Rights><object><name>Document.{name}</name></object></Rights>\n", encoding="utf-8"
     )
     (root / "EventSubscriptions" / "OnDocumentWrite.xml").write_text(
         f"<EventSubscription><Source>Document.{name}</Source></EventSubscription>\n", encoding="utf-8"
     )
     return root
+
+
+def write_admitted_repository(root: Path) -> tuple[Path, Path]:
+    snapshot = write_document_snapshot(root / ".local" / "targets" / "test" / "snapshot")
+    (snapshot / "Configuration.xml").write_text(
+        "<MetaDataObject><Configuration><Properties><Name>Test</Name><Version>1</Version></Properties>"
+        "<ChildObjects><Document>GoodsReceipt</Document></ChildObjects></Configuration></MetaDataObject>\n",
+        encoding="utf-8",
+    )
+    manifest = target_admission.tree_manifest(snapshot)
+    contract = {
+        "schemaVersion": 2,
+        "configuration": {"name": "Test", "version": "1"},
+        "source": {"kind": "hierarchical", "path": ".local/source", "contentId": "sha256:" + "0" * 64, "fileCount": 1},
+        "snapshot": {
+            "root": ".local/targets/test/snapshot",
+            "manifest": ".local/targets/test/snapshot.manifest",
+            "contentId": "sha256:" + hashlib.sha256(manifest).hexdigest(),
+            "fileCount": len(target_admission.manifest_entries(manifest)),
+        },
+        "dailyNativeRoute": "scripts/shared_task_route.py run",
+    }
+    (root / "project-target.json").write_text(json.dumps(contract), encoding="utf-8")
+    target = snapshot.parent
+    manifest_path = target / "snapshot.manifest"
+    binding = target / "source.json"
+    manifest_path.write_bytes(manifest)
+    binding.write_bytes(target_admission.binding_bytes(contract))
+    target_admission.freeze(snapshot, manifest_path, binding)
+    snapshot_ref = root / "snapshot-ref.json"
+    snapshot_ref.write_text(json.dumps(target_admission.snapshot_ref(contract, "reused")), encoding="utf-8")
+    return snapshot, snapshot_ref
 
 
 class ObjectContextTests(unittest.TestCase):
@@ -113,6 +177,10 @@ class ObjectContextTests(unittest.TestCase):
             )
             kinds = {item["kind"] for item in payload["relations"]["confirmed"]}
             self.assertEqual(kinds, {"configuration", "eventSubscription", "role"})
+            self.assertIn(
+                {"kind": "command", "locator": {"path": "Documents/GoodsReceipt/Commands/Print/Ext/Command.xml", "startLine": 1, "endLine": 1}},
+                payload["artifacts"],
+            )
             for section in (payload["metadata"]["attributes"], payload["bsl"]["outline"], payload["relations"]["confirmed"]):
                 for item in section:
                     self.assertIn("locator", item)
@@ -157,6 +225,77 @@ class ObjectContextTests(unittest.TestCase):
             payload = json.loads(result.stdout)
             self.assertEqual(payload["focusTerms"], ["Stock"])
             self.assertEqual([item["name"] for item in payload["metadata"]["attributes"]], ["Warehouse"])
+
+    def test_snapshot_ref_is_the_only_public_snapshot_input(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            _, snapshot_ref = write_admitted_repository(repo)
+
+            result = run_ref_inspect(repo, snapshot_ref, "--object", "Document.GoodsReceipt")
+            raw = subprocess.run(
+                [sys.executable, str(CLI), "inspect", "--snapshot", str(repo), "--object", "Document.GoodsReceipt"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(result.stdout)["status"], "ready")
+            self.assertNotEqual(raw.returncode, 0)
+            self.assertIn("required: --snapshot-ref", raw.stderr)
+
+    def test_forged_snapshot_ref_is_blocked_before_context_read(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            _, snapshot_ref = write_admitted_repository(repo)
+            forged = json.loads(snapshot_ref.read_text(encoding="utf-8"))
+            forged["snapshot"]["root"] = ".local/elsewhere"
+            snapshot_ref.write_text(json.dumps(forged), encoding="utf-8")
+
+            result = run_ref_inspect(repo, snapshot_ref, "--object", "Document.GoodsReceipt")
+
+            self.assertEqual(result.returncode, 2)
+            self.assertEqual(json.loads(result.stdout)["reasonCode"], "snapshot_ref_invalid")
+
+    def test_russian_bsl_procedures_are_outlined(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = write_document_snapshot(Path(temporary))
+            module = snapshot / "Documents" / "GoodsReceipt" / "Ext" / "ObjectModule.bsl"
+            module.write_text("Процедура Проведение(Отказ, РежимПроведения) Экспорт\nКонецПроцедуры\n", encoding="utf-8")
+
+            result = run_inspect(snapshot, "--object", "Document.GoodsReceipt")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertIn("Проведение", [item["name"] for item in payload["bsl"]["outline"]])
+
+    def test_non_relational_xml_text_does_not_become_confirmed_relation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = write_document_snapshot(Path(temporary))
+            (snapshot / "Roles" / "Purchases" / "Ext" / "Rights.xml").write_text(
+                "<Rights><Comment>Document.GoodsReceipt</Comment></Rights>\n", encoding="utf-8"
+            )
+
+            result = run_inspect(snapshot, "--object", "Document.GoodsReceipt")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertNotIn("role", {item["kind"] for item in payload["relations"]["confirmed"]})
+
+    def test_repeated_form_values_have_distinct_locators(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = write_document_snapshot(Path(temporary))
+            form = snapshot / "Documents" / "GoodsReceipt" / "Forms" / "DocumentForm" / "Ext" / "Form.xml"
+            form.write_text(
+                "<Form><DataPath>Object.Warehouse</DataPath>\n<DataPath>Object.Warehouse</DataPath></Form>\n",
+                encoding="utf-8",
+            )
+
+            result = run_inspect(snapshot, "--object", "Document.GoodsReceipt")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            paths = json.loads(result.stdout)["forms"][0]["dataPaths"]
+            self.assertEqual([item["locator"]["startLine"] for item in paths], [1, 2])
 
 
 if __name__ == "__main__":

--- a/tests/test_object_context.py
+++ b/tests/test_object_context.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts" / "object_context.py"
+
+
+def run_inspect(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLI), "inspect", "--snapshot", str(root), *arguments],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def write_document_snapshot(root: Path, name: str = "GoodsReceipt") -> Path:
+    (root / "Documents" / name / "Ext").mkdir(parents=True)
+    (root / "Documents" / name / "Forms" / "DocumentForm" / "Ext" / "Form").mkdir(parents=True)
+    (root / "Roles" / "Purchases" / "Ext").mkdir(parents=True)
+    (root / "EventSubscriptions").mkdir(parents=True)
+    (root / "Configuration.xml").write_text(
+        f"<Configuration><Documents><Document>{name}</Document></Documents></Configuration>\n",
+        encoding="utf-8",
+    )
+    (root / "Documents" / f"{name}.xml").write_text(
+        f"""<MetaDataObject>
+  <Document>
+    <Properties>
+      <Name>{name}</Name>
+      <Attributes>
+        <Attribute><Name>Warehouse</Name><Type>CatalogRef.Warehouses</Type></Attribute>
+      </Attributes>
+      <TabularSections>
+        <TabularSection><Name>Goods</Name><Attributes><Attribute><Name>Product</Name><Type>CatalogRef.Products</Type></Attribute></Attributes></TabularSection>
+      </TabularSections>
+      <Forms><Form>DocumentForm</Form></Forms>
+      <Templates><Template>PrintForm</Template></Templates>
+    </Properties>
+  </Document>
+</MetaDataObject>
+""",
+        encoding="utf-8",
+    )
+    (root / "Documents" / name / "Ext" / "ObjectModule.bsl").write_text(
+        """Procedure Posting(Cancel, PostingMode) Export
+    Movements.Stock.Write = True;
+EndProcedure
+
+Function CurrentWarehouse() Export
+    Return Warehouse;
+EndFunction
+""",
+        encoding="utf-8",
+    )
+    (root / "Documents" / name / "Ext" / "ManagerModule.bsl").write_text(
+        "Procedure Initialize()\nEndProcedure\n",
+        encoding="utf-8",
+    )
+    (root / "Documents" / name / "Forms" / "DocumentForm" / "Ext" / "Form.xml").write_text(
+        """<Form>
+  <Events><Event name="OnOpen">OnOpen</Event></Events>
+  <Items>
+    <InputField><DataPath>Object.Warehouse</DataPath><Events><Event name="OnChange">WarehouseOnChange</Event></Events></InputField>
+    <CommandBar><CommandName>Form.Command.Post</CommandName></CommandBar>
+  </Items>
+  <Command><Name>Post</Name><Action>Posting</Action></Command>
+</Form>
+""",
+        encoding="utf-8",
+    )
+    (root / "Documents" / name / "Forms" / "DocumentForm" / "Ext" / "Form" / "Module.bsl").write_text(
+        "Procedure OnOpen(Cancel)\nEndProcedure\nProcedure WarehouseOnChange(Item)\nEndProcedure\n",
+        encoding="utf-8",
+    )
+    (root / "Roles" / "Purchases" / "Ext" / "Rights.xml").write_text(
+        f"<Rights><name>Document.{name}</name></Rights>\n", encoding="utf-8"
+    )
+    (root / "EventSubscriptions" / "OnDocumentWrite.xml").write_text(
+        f"<EventSubscription><Source>Document.{name}</Source></EventSubscription>\n", encoding="utf-8"
+    )
+    return root
+
+
+class ObjectContextTests(unittest.TestCase):
+    def test_document_inspection_is_stable_bounded_and_cited(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = write_document_snapshot(Path(temporary))
+            before = {p.relative_to(snapshot): p.read_bytes() for p in snapshot.rglob("*") if p.is_file()}
+
+            first = run_inspect(snapshot, "--object", "Document.GoodsReceipt")
+            second = run_inspect(snapshot, "--object", "Document.GoodsReceipt")
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(first.stdout, second.stdout)
+            self.assertLessEqual(len(first.stdout.encode("utf-8")), 32 * 1024)
+            payload = json.loads(first.stdout)
+            self.assertEqual(payload["status"], "ready")
+            self.assertEqual(payload["object"]["canonicalName"], "Document.GoodsReceipt")
+            self.assertEqual([item["name"] for item in payload["metadata"]["attributes"]], ["Warehouse"])
+            self.assertEqual([item["name"] for item in payload["metadata"]["tabularSections"]], ["Goods"])
+            self.assertEqual(
+                [item["name"] for item in payload["bsl"]["outline"]],
+                ["CurrentWarehouse", "Initialize", "OnOpen", "Posting", "WarehouseOnChange"],
+            )
+            self.assertEqual(
+                [item["value"] for item in payload["forms"][0]["dataPaths"]],
+                ["Object.Warehouse"],
+            )
+            kinds = {item["kind"] for item in payload["relations"]["confirmed"]}
+            self.assertEqual(kinds, {"configuration", "eventSubscription", "role"})
+            for section in (payload["metadata"]["attributes"], payload["bsl"]["outline"], payload["relations"]["confirmed"]):
+                for item in section:
+                    self.assertIn("locator", item)
+                    self.assertIn("path", item["locator"])
+                    self.assertIn("startLine", item["locator"])
+            after = {p.relative_to(snapshot): p.read_bytes() for p in snapshot.rglob("*") if p.is_file()}
+            self.assertEqual(before, after)
+
+    def test_invalid_missing_and_unsupported_inputs_have_distinct_states(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = write_document_snapshot(Path(temporary))
+            invalid = run_inspect(snapshot, "--object", "GoodsReceipt")
+            missing = run_inspect(snapshot, "--object", "Document.Missing")
+            unsupported = run_inspect(snapshot, "--object", "Catalog.Goods")
+            absent_snapshot = run_inspect(snapshot / "absent", "--object", "Document.GoodsReceipt")
+
+            self.assertEqual((invalid.returncode, json.loads(invalid.stdout)["reasonCode"]), (2, "invalid_object"))
+            self.assertEqual((missing.returncode, json.loads(missing.stdout)["reasonCode"]), (2, "object_not_found"))
+            self.assertEqual((unsupported.returncode, json.loads(unsupported.stdout)["status"]), (0, "unsupported"))
+            self.assertEqual((absent_snapshot.returncode, json.loads(absent_snapshot.stdout)["reasonCode"]), (2, "snapshot_unavailable"))
+
+    def test_limits_mark_truncation_without_hiding_it(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = write_document_snapshot(Path(temporary))
+            result = run_inspect(snapshot, "--object", "Document.GoodsReceipt", "--limit", "1")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertTrue(payload["truncated"])
+            self.assertLessEqual(len(payload["bsl"]["outline"]), 1)
+            self.assertTrue(payload["diagnostics"])
+
+    def test_focus_terms_are_stable_and_only_filter_lexical_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = write_document_snapshot(Path(temporary))
+
+            result = run_inspect(
+                snapshot, "--object", "Document.GoodsReceipt", "--focus", "Stock", "--focus", "Stock"
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["focusTerms"], ["Stock"])
+            self.assertEqual([item["name"] for item in payload["metadata"]["attributes"]], ["Warehouse"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## NO MATERIAL WIN — owner review checkpoint

The correction closes the contract gaps, but the Goal #58 product threshold is not met. This PR remains **draft/open**; merge is not authorized.

### Exact candidate

- head: `192ab394c4f53a4ee7759b0f3d23e56055945482`
- tree: `e79740ea01562a2732b1e052b1ea7ce922472bc3`

### Corrected public boundary

```bash
python3 scripts/project_target.py open > .local/snapshot-ref.json
python3 scripts/object_context.py inspect --snapshot-ref .local/snapshot-ref.json --object Document.<Name>
```

`inspect` has no raw `--snapshot` public path. It compares the data-only serialized `SnapshotRef` with the current project contract and delegates retained-target validation to the existing authoritative `target_admission.admit_target`; it does not add admission/materialization/runtime policy.

Other corrected contracts: confirmed relations come only from specific XML positions; comments cannot become confirmed links; BSL outline accepts English and Russian Procedure/Function spellings; repeated XML values have distinct locators; owned Commands are reported.

### Exact aggregate evaluation

The #51 `rg` baseline is already the aggregate three-task route: **96,313 B / 36 search+read operations**. It must not be multiplied by three.

| Frozen task | owner / procedure / patch boundary | extra source reads after inspector | full-route bytes | operations |
|---|---|---|---:|---:|
| deleted SupplierInvoice warehouse | `Document.SupplierInvoice` / ObjectModule `Posting` / early posting guard | `Documents/SupplierInvoice/Ext/ObjectModule.bsl:11-40` (1,215 B) | 23,707 | 2 |
| equal InventoryTransfer warehouses | `Document.InventoryTransfer` / ObjectModule `Posting` / early posting guard | `Documents/InventoryTransfer/Ext/ObjectModule.bsl:11-34` (947 B) | 15,338 | 2 |
| SalesInvoice PaymentDueDate | `Document.SalesInvoice` / ObjectModule `Posting` / early posting guard | `Documents/SalesInvoice/Ext/ObjectModule.bsl:14-56` (1,944 B); `Documents/BankPayment.xml:568-612` precedent (1,408 B) | 31,081 | 3 |

Aggregate: **70,126 B / 7 operations**. That is **27.19% byte reduction** and **80.56% operation reduction**. The byte target requires at most 57,787.8 B (40% reduction), so it fails. The front-door-only result was already 64,612 B (32.91% reduction); mandatory procedure/precedent reads make the full route larger.

### Post-freeze read-only canary

On the restored executor, an isolated exact-head worktree copied only the already admitted immutable retained target, then performed:

1. `project_target.py open --repo-root <worktree>` → ready `SnapshotRef`, `action=reused`;
2. `object_context.py inspect --snapshot-ref ...` twice each for SupplierInvoice, InventoryTransfer and SalesInvoice, with warnings treated as errors.

All three pairs were byte-identical. Snapshot manifest was unchanged (`70972b5e11901ca31c7f7ec67dca03f78986206b024be01aeb34e0e1f3ff6691`) and no 1C/Xvfb process was created. Measured open: 3.750 s; inspection calls: 4.541 s / 14,391 B, 4.021 s / 27,729 B, 4.049 s / 22,492 B respectively. No native 1C route was run.

### Checks

- local full suite: **225 PASS**; `PYTHONWARNINGS=error::DeprecationWarning`, `py_compile`, `git diff --check`: PASS
- exact-head CI Python 3.9 and 3.12: PASS — https://github.com/Kwentin3/1c-agent-harness/actions/runs/33803545780

The implementation remains a correct read-only navigation aid, but Goal #58 defines this situation as `NO MATERIAL WIN`, not a product route.
