### PR TITLE
feat: make configuration search available on fresh executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,35 @@ Admission в `project_target.py` проверяет закрытый manifest/fi
 проверяет и переиспользует тот же retained target без source и native-запуска; повреждённый target
 не исправляется и не перезаписывается.
 
-Для этого проекта target — canonical JetTr `1.0.3.1`. Полученный `snapshot.root` передаётся
-следующим read-only инструментам. Для разрешённых прикладных write-проверок task-specific копия
-размещается отдельно под `.local/prepared/`. Единственная продуктовая команда такой проверки —
+Для этого проекта target — canonical JetTr `1.0.3.1`. Полученный data-only `SnapshotRef`
+передаётся следующим read-only инструментам.
+
+### Поиск по admitted snapshot (V1)
+
+Готовый маршрут для fresh executor — `open → search`. Сначала сохранить единственный
+machine-readable `SnapshotRef`, затем передать именно этот файл поиску:
+
+```bash
+mkdir -p .local/search-session
+python3 scripts/project_target.py open --repo-root . \
+  > .local/search-session/snapshot-ref.json
+
+python3 scripts/snapshot_search.py \
+  --repo-root . \
+  --snapshot-ref .local/search-session/snapshot-ref.json \
+  --query 'Procedure\\s+Posting' \
+  --mode regex \
+  --path-prefix Documents/SalesInvoice/Ext
+```
+
+`open` остаётся единственным владельцем source, contract, retained storage и admission.
+`search` принимает только точный data-only `SnapshotRef`, разрешает его через target boundary и
+читает manifest-declared файлы. V1 намеренно ищет только `.bsl` и `.xml`; системный `rg`, сеть,
+1С, индекс, cache и parser не требуются. Результат — deterministic JSON с relative `path`, `line`,
+bounded `fragment` и явным `truncated`; доступны `literal` и `regex` modes и относительный
+`--path-prefix`.
+
+Для разрешённых прикладных write-проверок task-specific копия размещается отдельно под `.local/prepared/`. Единственная продуктовая команда такой проверки —
 [`scripts/shared_task_route.py run`](scripts/shared_task_route.py). Она сама создаёт disposable
 prepared path, применяет task-owned exact patches, вычисляет derived identities, вызывает
 низкоуровневый `native_cycle.py run-prepared`, передаёт raw receipts предметному oracle, возвращает

--- a/scripts/snapshot_search.py
+++ b/scripts/snapshot_search.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 import json
 from pathlib import Path, PurePosixPath
 import re
+import signal
 import sys
 from typing import Iterator
 
@@ -22,8 +24,10 @@ from target_admission import (
 SCHEMA_VERSION = 1
 DEFAULT_LIMIT = 20
 DEFAULT_MAX_BYTES = 32 * 1024
+MIN_MAX_BYTES = 256
 MAX_QUERY_BYTES = 512
 MAX_FRAGMENT_BYTES = 512
+SEARCH_DEADLINE_SECONDS = 9.0
 
 
 class SearchBlocked(Exception):
@@ -44,6 +48,37 @@ def _blocked(reason_code: str, message: str) -> dict[str, object]:
 
 def _dump(payload: dict[str, object]) -> str:
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _stdout_bytes(payload: dict[str, object]) -> bytes:
+    return (_dump(payload) + "\n").encode("utf-8")
+
+
+def _write(payload: dict[str, object], maximum: int) -> None:
+    encoded = _stdout_bytes(payload)
+    if len(encoded) > maximum:
+        raise SearchBlocked("output_limit", "response exceeds byte limit")
+    sys.stdout.buffer.write(encoded)
+
+
+@contextmanager
+def _deadline(seconds: float) -> Iterator[None]:
+    if not hasattr(signal, "setitimer") or not hasattr(signal, "ITIMER_REAL"):
+        raise SearchBlocked("search_failed", "deadline enforcement is unavailable")
+    if signal.getitimer(signal.ITIMER_REAL) != (0.0, 0.0):
+        raise SearchBlocked("search_failed", "deadline enforcement is unavailable")
+    previous_handler = signal.getsignal(signal.SIGALRM)
+
+    def expired(_signum: int, _frame: object) -> None:
+        raise SearchBlocked("deadline_exceeded", "search deadline exceeded")
+
+    signal.signal(signal.SIGALRM, expired)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
 
 
 def _bounded_text(value: object, *, name: str, maximum: int) -> str:
@@ -86,13 +121,15 @@ def _read_snapshot_ref(path: Path, contract: dict[str, object]) -> None:
         raise SearchBlocked("snapshot_invalid", "SnapshotRef is not admitted") from exc
 
 
-def _admitted_snapshot(repo_root: Path, ref_path: Path) -> tuple[Path, dict[str, str]]:
+def _admitted_snapshot(
+    repo_root: Path, ref_path: Path
+) -> tuple[Path, dict[str, str], tuple[Path, Path, Path, dict[str, object]]]:
     try:
         contract, _ = load_contract(repo_root)
         _read_snapshot_ref(ref_path, contract)
         _base, target, snapshot, manifest, binding = paths(repo_root, contract)
         admit_target(target, snapshot, manifest, binding, contract)
-        return snapshot, manifest_entries(manifest.read_bytes())
+        return snapshot, manifest_entries(manifest.read_bytes()), (target, manifest, binding, contract)
     except SearchBlocked:
         raise
     except (OSError, TargetBlocked, ValueError) as exc:
@@ -119,14 +156,17 @@ def _matching_lines(snapshot: Path, entries: dict[str, str], matcher: re.Pattern
     for relative in sorted(entries):
         if prefix is not None and relative != prefix and not relative.startswith(prefix + "/"):
             continue
+        if PurePosixPath(relative).suffix.casefold() not in {".bsl", ".xml"}:
+            continue
         path = snapshot / relative
         try:
-            payload = path.read_bytes()
+            with path.open("rb") as snapshot_file:
+                payload = snapshot_file.read()
             if b"\0" in payload:
-                continue
+                raise ValueError("binary snapshot content")
             text = payload.decode("utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            raise SearchBlocked("snapshot_invalid", "Snapshot content is unreadable") from exc
         for line_number, line in enumerate(text.splitlines(), start=1):
             if matcher.search(line):
                 yield {"fragment": _fragment(line), "line": line_number, "path": relative}
@@ -153,22 +193,28 @@ def search(repo_root: Path, snapshot_ref_path: Path, query: str, mode: str, path
         matcher = re.compile(pattern)
     except re.error as exc:
         raise SearchBlocked("invalid_request", "query regex is invalid") from exc
-    snapshot, entries = _admitted_snapshot(repo_root, snapshot_ref_path)
-    results: list[dict[str, object]] = []
-    truncated = False
-    for hit in _matching_lines(snapshot, entries, matcher, path_prefix):
-        if len(results) >= limit:
-            truncated = True
-            break
-        candidate = results + [hit]
-        if len(_dump(_result(query, mode, path_prefix, candidate, True)).encode("utf-8")) > max_bytes:
-            truncated = True
-            break
-        results.append(hit)
-    payload = _result(query, mode, path_prefix, results, truncated)
-    if len(_dump(payload).encode("utf-8")) > max_bytes:
-        raise SearchBlocked("invalid_request", "maxBytes is too small")
-    return payload
+    with _deadline(SEARCH_DEADLINE_SECONDS):
+        snapshot, entries, admitted = _admitted_snapshot(repo_root, snapshot_ref_path)
+        results: list[dict[str, object]] = []
+        truncated = False
+        for hit in _matching_lines(snapshot, entries, matcher, path_prefix):
+            if len(results) >= limit:
+                truncated = True
+                break
+            candidate = results + [hit]
+            if len(_stdout_bytes(_result(query, mode, path_prefix, candidate, False))) > max_bytes:
+                truncated = True
+                break
+            results.append(hit)
+        target, manifest, binding, contract = admitted
+        try:
+            admit_target(target, snapshot, manifest, binding, contract)
+        except (OSError, TargetBlocked, ValueError) as exc:
+            raise SearchBlocked("snapshot_invalid", "SnapshotRef changed during search") from exc
+        payload = _result(query, mode, path_prefix, results, truncated)
+        if len(_stdout_bytes(payload)) > max_bytes:
+            raise SearchBlocked("invalid_request", "maxBytes is too small")
+        return payload
 
 
 def main() -> int:
@@ -181,19 +227,23 @@ def main() -> int:
     parser.add_argument("--limit", default=str(DEFAULT_LIMIT))
     parser.add_argument("--max-bytes", default=str(DEFAULT_MAX_BYTES))
     args = parser.parse_args()
+    output_limit = DEFAULT_MAX_BYTES
     try:
         query = _bounded_text(args.query, name="query", maximum=MAX_QUERY_BYTES)
         limit = _positive(args.limit, name="limit", maximum=100)
         max_bytes = _positive(args.max_bytes, name="maxBytes", maximum=DEFAULT_MAX_BYTES)
+        if max_bytes < MIN_MAX_BYTES:
+            raise SearchBlocked("invalid_request", "maxBytes is invalid")
+        output_limit = max_bytes
         prefix = _path_prefix(args.path_prefix)
         payload = search(args.repo_root.resolve(), args.snapshot_ref, query, args.mode, prefix, limit, max_bytes)
-        print(_dump(payload))
+        _write(payload, output_limit)
         return 0
     except SearchBlocked as exc:
-        print(_dump(_blocked(exc.reason_code, exc.message)))
+        _write(_blocked(exc.reason_code, exc.message), output_limit)
         return 1
     except Exception:
-        print(_dump(_blocked("search_failed", "search could not complete")))
+        _write(_blocked("search_failed", "search could not complete"), output_limit)
         return 1
 
 

--- a/scripts/snapshot_search.py
+++ b/scripts/snapshot_search.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Search an admitted 1C SnapshotRef without executor-provided tools."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import re
+import sys
+from typing import Iterator
+
+from target_admission import (
+    TargetBlocked,
+    admit_target,
+    load_contract,
+    manifest_entries,
+    paths,
+    snapshot_ref,
+    unique_object,
+)
+
+SCHEMA_VERSION = 1
+DEFAULT_LIMIT = 20
+DEFAULT_MAX_BYTES = 32 * 1024
+MAX_QUERY_BYTES = 512
+MAX_FRAGMENT_BYTES = 512
+
+
+class SearchBlocked(Exception):
+    def __init__(self, reason_code: str, message: str) -> None:
+        self.reason_code = reason_code
+        self.message = message
+        super().__init__(message)
+
+
+def _blocked(reason_code: str, message: str) -> dict[str, object]:
+    return {
+        "message": message,
+        "reasonCode": reason_code,
+        "schemaVersion": SCHEMA_VERSION,
+        "status": "blocked",
+    }
+
+
+def _dump(payload: dict[str, object]) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _bounded_text(value: object, *, name: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > maximum:
+        raise SearchBlocked("invalid_request", f"{name} is invalid")
+    return value
+
+
+def _positive(value: str, *, name: str, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise SearchBlocked("invalid_request", f"{name} is invalid") from exc
+    if parsed < 1 or parsed > maximum:
+        raise SearchBlocked("invalid_request", f"{name} is invalid")
+    return parsed
+
+
+def _path_prefix(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not value or len(value.encode("utf-8")) > MAX_QUERY_BYTES:
+        raise SearchBlocked("invalid_request", "pathPrefix is invalid")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or any(not part or part == "." for part in path.parts):
+        raise SearchBlocked("invalid_request", "pathPrefix is invalid")
+    return path.as_posix()
+
+
+def _read_snapshot_ref(path: Path, contract: dict[str, object]) -> None:
+    try:
+        if path.is_symlink() or not path.is_file() or path.stat().st_size > 16 * 1024:
+            raise ValueError("invalid snapshot reference")
+        actual = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=unique_object)
+        if not isinstance(actual, dict) or actual.get("action") not in {"materialized", "reused"}:
+            raise ValueError("invalid snapshot reference")
+        if actual != snapshot_ref(contract, str(actual["action"])):
+            raise ValueError("snapshot reference does not match target")
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        raise SearchBlocked("snapshot_invalid", "SnapshotRef is not admitted") from exc
+
+
+def _admitted_snapshot(repo_root: Path, ref_path: Path) -> tuple[Path, dict[str, str]]:
+    try:
+        contract, _ = load_contract(repo_root)
+        _read_snapshot_ref(ref_path, contract)
+        _base, target, snapshot, manifest, binding = paths(repo_root, contract)
+        admit_target(target, snapshot, manifest, binding, contract)
+        return snapshot, manifest_entries(manifest.read_bytes())
+    except SearchBlocked:
+        raise
+    except (OSError, TargetBlocked, ValueError) as exc:
+        raise SearchBlocked("snapshot_invalid", "SnapshotRef is not admitted") from exc
+
+
+def _fragment(line: str) -> str:
+    compact = line.strip()
+    encoded = compact.encode("utf-8")
+    if len(encoded) <= MAX_FRAGMENT_BYTES:
+        return compact
+    kept: list[str] = []
+    used = len("…".encode("utf-8"))
+    for character in compact:
+        size = len(character.encode("utf-8"))
+        if used + size > MAX_FRAGMENT_BYTES:
+            break
+        kept.append(character)
+        used += size
+    return "".join(kept) + "…"
+
+
+def _matching_lines(snapshot: Path, entries: dict[str, str], matcher: re.Pattern[str], prefix: str | None) -> Iterator[dict[str, object]]:
+    for relative in sorted(entries):
+        if prefix is not None and relative != prefix and not relative.startswith(prefix + "/"):
+            continue
+        path = snapshot / relative
+        try:
+            payload = path.read_bytes()
+            if b"\0" in payload:
+                continue
+            text = payload.decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if matcher.search(line):
+                yield {"fragment": _fragment(line), "line": line_number, "path": relative}
+
+
+def _result(query: str, mode: str, prefix: str | None, results: list[dict[str, object]], truncated: bool) -> dict[str, object]:
+    request: dict[str, object] = {"mode": mode, "value": query}
+    if prefix is not None:
+        request["pathPrefix"] = prefix
+    return {
+        "query": request,
+        "results": results,
+        "schemaVersion": SCHEMA_VERSION,
+        "status": "ok",
+        "truncated": truncated,
+    }
+
+
+def search(repo_root: Path, snapshot_ref_path: Path, query: str, mode: str, path_prefix: str | None, limit: int, max_bytes: int) -> dict[str, object]:
+    if mode not in {"literal", "regex"}:
+        raise SearchBlocked("invalid_request", "mode is invalid")
+    pattern = re.escape(query) if mode == "literal" else query
+    try:
+        matcher = re.compile(pattern)
+    except re.error as exc:
+        raise SearchBlocked("invalid_request", "query regex is invalid") from exc
+    snapshot, entries = _admitted_snapshot(repo_root, snapshot_ref_path)
+    results: list[dict[str, object]] = []
+    truncated = False
+    for hit in _matching_lines(snapshot, entries, matcher, path_prefix):
+        if len(results) >= limit:
+            truncated = True
+            break
+        candidate = results + [hit]
+        if len(_dump(_result(query, mode, path_prefix, candidate, True)).encode("utf-8")) > max_bytes:
+            truncated = True
+            break
+        results.append(hit)
+    payload = _result(query, mode, path_prefix, results, truncated)
+    if len(_dump(payload).encode("utf-8")) > max_bytes:
+        raise SearchBlocked("invalid_request", "maxBytes is too small")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--snapshot-ref", type=Path, required=True)
+    parser.add_argument("--query", required=True)
+    parser.add_argument("--mode", default="literal")
+    parser.add_argument("--path-prefix")
+    parser.add_argument("--limit", default=str(DEFAULT_LIMIT))
+    parser.add_argument("--max-bytes", default=str(DEFAULT_MAX_BYTES))
+    args = parser.parse_args()
+    try:
+        query = _bounded_text(args.query, name="query", maximum=MAX_QUERY_BYTES)
+        limit = _positive(args.limit, name="limit", maximum=100)
+        max_bytes = _positive(args.max_bytes, name="maxBytes", maximum=DEFAULT_MAX_BYTES)
+        prefix = _path_prefix(args.path_prefix)
+        payload = search(args.repo_root.resolve(), args.snapshot_ref, query, args.mode, prefix, limit, max_bytes)
+        print(_dump(payload))
+        return 0
+    except SearchBlocked as exc:
+        print(_dump(_blocked(exc.reason_code, exc.message)))
+        return 1
+    except Exception:
+        print(_dump(_blocked("search_failed", "search could not complete")))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/snapshot_search.py
+++ b/scripts/snapshot_search.py
@@ -3,22 +3,15 @@
 from __future__ import annotations
 
 import argparse
-from contextlib import contextmanager
 import json
 from pathlib import Path, PurePosixPath
 import re
-import signal
 import sys
 from typing import Iterator
 
 from target_admission import (
     TargetBlocked,
-    admit_target,
-    load_contract,
-    manifest_entries,
-    paths,
-    snapshot_ref,
-    unique_object,
+    resolve_snapshot_ref,
 )
 
 SCHEMA_VERSION = 1
@@ -27,7 +20,6 @@ DEFAULT_MAX_BYTES = 32 * 1024
 MIN_MAX_BYTES = 256
 MAX_QUERY_BYTES = 512
 MAX_FRAGMENT_BYTES = 512
-SEARCH_DEADLINE_SECONDS = 9.0
 
 
 class SearchBlocked(Exception):
@@ -61,26 +53,6 @@ def _write(payload: dict[str, object], maximum: int) -> None:
     sys.stdout.buffer.write(encoded)
 
 
-@contextmanager
-def _deadline(seconds: float) -> Iterator[None]:
-    if not hasattr(signal, "setitimer") or not hasattr(signal, "ITIMER_REAL"):
-        raise SearchBlocked("search_failed", "deadline enforcement is unavailable")
-    if signal.getitimer(signal.ITIMER_REAL) != (0.0, 0.0):
-        raise SearchBlocked("search_failed", "deadline enforcement is unavailable")
-    previous_handler = signal.getsignal(signal.SIGALRM)
-
-    def expired(_signum: int, _frame: object) -> None:
-        raise SearchBlocked("deadline_exceeded", "search deadline exceeded")
-
-    signal.signal(signal.SIGALRM, expired)
-    signal.setitimer(signal.ITIMER_REAL, seconds)
-    try:
-        yield
-    finally:
-        signal.setitimer(signal.ITIMER_REAL, 0)
-        signal.signal(signal.SIGALRM, previous_handler)
-
-
 def _bounded_text(value: object, *, name: str, maximum: int) -> str:
     if not isinstance(value, str) or not value or len(value.encode("utf-8")) > maximum:
         raise SearchBlocked("invalid_request", f"{name} is invalid")
@@ -108,31 +80,10 @@ def _path_prefix(value: str | None) -> str | None:
     return path.as_posix()
 
 
-def _read_snapshot_ref(path: Path, contract: dict[str, object]) -> None:
+def _admitted_snapshot(repo_root: Path, ref_path: Path) -> tuple[Path, dict[str, str]]:
     try:
-        if path.is_symlink() or not path.is_file() or path.stat().st_size > 16 * 1024:
-            raise ValueError("invalid snapshot reference")
-        actual = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=unique_object)
-        if not isinstance(actual, dict) or actual.get("action") not in {"materialized", "reused"}:
-            raise ValueError("invalid snapshot reference")
-        if actual != snapshot_ref(contract, str(actual["action"])):
-            raise ValueError("snapshot reference does not match target")
-    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
-        raise SearchBlocked("snapshot_invalid", "SnapshotRef is not admitted") from exc
-
-
-def _admitted_snapshot(
-    repo_root: Path, ref_path: Path
-) -> tuple[Path, dict[str, str], tuple[Path, Path, Path, dict[str, object]]]:
-    try:
-        contract, _ = load_contract(repo_root)
-        _read_snapshot_ref(ref_path, contract)
-        _base, target, snapshot, manifest, binding = paths(repo_root, contract)
-        admit_target(target, snapshot, manifest, binding, contract)
-        return snapshot, manifest_entries(manifest.read_bytes()), (target, manifest, binding, contract)
-    except SearchBlocked:
-        raise
-    except (OSError, TargetBlocked, ValueError) as exc:
+        return resolve_snapshot_ref(repo_root, ref_path)
+    except TargetBlocked as exc:
         raise SearchBlocked("snapshot_invalid", "SnapshotRef is not admitted") from exc
 
 
@@ -193,28 +144,22 @@ def search(repo_root: Path, snapshot_ref_path: Path, query: str, mode: str, path
         matcher = re.compile(pattern)
     except re.error as exc:
         raise SearchBlocked("invalid_request", "query regex is invalid") from exc
-    with _deadline(SEARCH_DEADLINE_SECONDS):
-        snapshot, entries, admitted = _admitted_snapshot(repo_root, snapshot_ref_path)
-        results: list[dict[str, object]] = []
-        truncated = False
-        for hit in _matching_lines(snapshot, entries, matcher, path_prefix):
-            if len(results) >= limit:
-                truncated = True
-                break
-            candidate = results + [hit]
-            if len(_stdout_bytes(_result(query, mode, path_prefix, candidate, False))) > max_bytes:
-                truncated = True
-                break
-            results.append(hit)
-        target, manifest, binding, contract = admitted
-        try:
-            admit_target(target, snapshot, manifest, binding, contract)
-        except (OSError, TargetBlocked, ValueError) as exc:
-            raise SearchBlocked("snapshot_invalid", "SnapshotRef changed during search") from exc
-        payload = _result(query, mode, path_prefix, results, truncated)
-        if len(_stdout_bytes(payload)) > max_bytes:
-            raise SearchBlocked("invalid_request", "maxBytes is too small")
-        return payload
+    snapshot, entries = _admitted_snapshot(repo_root, snapshot_ref_path)
+    results: list[dict[str, object]] = []
+    truncated = False
+    for hit in _matching_lines(snapshot, entries, matcher, path_prefix):
+        if len(results) >= limit:
+            truncated = True
+            break
+        candidate = results + [hit]
+        if len(_stdout_bytes(_result(query, mode, path_prefix, candidate, False))) > max_bytes:
+            truncated = True
+            break
+        results.append(hit)
+    payload = _result(query, mode, path_prefix, results, truncated)
+    if len(_stdout_bytes(payload)) > max_bytes:
+        raise SearchBlocked("invalid_request", "maxBytes is too small")
+    return payload
 
 
 def main() -> int:

--- a/scripts/target_admission.py
+++ b/scripts/target_admission.py
@@ -227,3 +227,23 @@ def snapshot_ref(contract: dict[str, object], action: str) -> dict[str, object]:
     snapshot = contract["snapshot"]; configuration = contract["configuration"]
     assert isinstance(snapshot, dict) and isinstance(configuration, dict)
     return {"schemaVersion": 1, "status": "ready", "action": action, "sourceIdentity": source_identity(contract), "snapshot": {"kind": "1c-configuration-files", "format": "hierarchical", "root": snapshot["root"], "manifest": snapshot["manifest"], "contentId": snapshot["contentId"], "fileCount": snapshot["fileCount"], "configuration": configuration}}
+
+
+def resolve_snapshot_ref(repo_root: Path, ref_path: Path) -> tuple[Path, dict[str, str]]:
+    """Resolve one exact data-only SnapshotRef through the retained-target boundary."""
+    try:
+        contract, _ = load_contract(repo_root)
+        if ref_path.is_symlink() or not ref_path.is_file() or ref_path.stat().st_size > 16 * 1024:
+            raise ValueError("invalid snapshot reference")
+        actual = json.loads(ref_path.read_text(encoding="utf-8"), object_pairs_hook=unique_object)
+        if not isinstance(actual, dict) or actual.get("action") not in {"materialized", "reused"}:
+            raise ValueError("invalid snapshot reference")
+        if actual != snapshot_ref(contract, str(actual["action"])):
+            raise ValueError("snapshot reference does not match target")
+        _base, target, snapshot, manifest, binding = paths(repo_root, contract)
+        admit_target(target, snapshot, manifest, binding, contract)
+        return snapshot, manifest_entries(manifest.read_bytes())
+    except TargetBlocked:
+        raise
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        raise TargetBlocked("snapshot_invalid", "SnapshotRef is not admitted") from exc

--- a/tests/test_snapshot_search.py
+++ b/tests/test_snapshot_search.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
-import time
 import unittest
 from unittest.mock import patch
 
@@ -166,23 +165,17 @@ class SnapshotSearchTests(unittest.TestCase):
                     None,
                 ))
 
-    def test_deadline_interrupts_a_slow_post_admission_scan(self) -> None:
+    def test_search_uses_one_target_owned_snapshot_resolver(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             _, _, ref = create_target(root)
+            resolved = target_admission.resolve_snapshot_ref(root, ref)
 
-            admitted = snapshot_search._admitted_snapshot(root, ref)
+            with patch.object(snapshot_search, "resolve_snapshot_ref", return_value=resolved) as resolver:
+                payload = snapshot_search.search(root, ref, "PaymentDueDate", "literal", None, 20, 32 * 1024)
 
-            def late_hits(*_args: object):
-                time.sleep(0.03)
-                if False:
-                    yield {}
-
-            with patch.object(snapshot_search, "SEARCH_DEADLINE_SECONDS", 0.01), patch.object(
-                snapshot_search, "_admitted_snapshot", return_value=admitted
-            ), patch.object(snapshot_search, "_matching_lines", late_hits):
-                with self.assertRaisesRegex(snapshot_search.SearchBlocked, "deadline"):
-                    snapshot_search.search(root, ref, "PaymentDueDate", "literal", None, 20, 32 * 1024)
+            self.assertEqual(payload["status"], "ok")
+            resolver.assert_called_once_with(root, ref)
 
     def test_path_prefix_limits_search_to_declared_subtree(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_snapshot_search.py
+++ b/tests/test_snapshot_search.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts" / "snapshot_search.py"
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import target_admission
+
+
+def digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def create_target(root: Path) -> tuple[Path, Path, Path]:
+    snapshot = root / ".local/targets/sample/snapshot"
+    files = {
+        "Configuration.xml": (
+            "<MetaDataObject><Configuration><Properties>"
+            "<Name>Sample</Name><Version>2.0</Version>"
+            "</Properties></Configuration></MetaDataObject>"
+        ),
+        "Documents/SalesInvoice.xml": "<Attribute><Name>PaymentDueDate</Name></Attribute>",
+        "Documents/SalesInvoice/Ext/ObjectModule.bsl": "Procedure Posting(Cancel)\nEndProcedure\n",
+        "Documents/SalesInvoice/Templates/PrintData/Ext/Template.xml": (
+            "<field><dataPath>PaymentDueDate</dataPath></field>"
+        ),
+    }
+    for relative, text in files.items():
+        path = snapshot / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    manifest = target_admission.tree_manifest(snapshot)
+    contract = {
+        "schemaVersion": 2,
+        "configuration": {"name": "Sample", "version": "2.0"},
+        "source": {
+            "kind": "hierarchical",
+            "path": ".local/source/export",
+            "contentId": f"sha256:{digest(manifest)}",
+            "fileCount": 4,
+        },
+        "snapshot": {
+            "root": ".local/targets/sample/snapshot",
+            "manifest": ".local/targets/sample/snapshot.manifest",
+            "contentId": f"sha256:{digest(manifest)}",
+            "fileCount": 4,
+        },
+        "dailyNativeRoute": "scripts/shared_task_route.py run",
+    }
+    (root / "project-target.json").write_text(json.dumps(contract), encoding="utf-8")
+    manifest_path = snapshot.parent / "snapshot.manifest"
+    binding_path = snapshot.parent / "source.json"
+    manifest_path.write_bytes(manifest)
+    binding_path.write_bytes(target_admission.binding_bytes(contract))
+    target_admission.freeze(snapshot, manifest_path, binding_path)
+    ref = root / "snapshot-ref.json"
+    ref.write_text(json.dumps(target_admission.snapshot_ref(contract, "reused")), encoding="utf-8")
+    return snapshot, manifest_path, ref
+
+
+def run_search(root: Path, ref: Path, query: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--repo-root",
+            str(root),
+            "--snapshot-ref",
+            str(ref),
+            "--query",
+            query,
+            *args,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "PATH": ""},
+    )
+
+
+class SnapshotSearchTests(unittest.TestCase):
+    def test_search_without_system_rg_finds_bsl_and_xml_with_stable_paths_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            snapshot, manifest, ref = create_target(root)
+            before = (target_admission.tree_manifest(snapshot), manifest.read_bytes())
+
+            bsl = run_search(root, ref, r"Procedure\s+Posting", "--mode", "regex")
+            xml = run_search(root, ref, "PaymentDueDate", "--mode", "literal")
+
+            self.assertEqual(bsl.returncode, 0, bsl.stderr)
+            self.assertEqual(xml.returncode, 0, xml.stderr)
+            self.assertEqual(json.loads(bsl.stdout)["results"], [{
+                "fragment": "Procedure Posting(Cancel)",
+                "line": 1,
+                "path": "Documents/SalesInvoice/Ext/ObjectModule.bsl",
+            }])
+            self.assertEqual(
+                [(item["path"], item["line"]) for item in json.loads(xml.stdout)["results"]],
+                [
+                    ("Documents/SalesInvoice.xml", 1),
+                    ("Documents/SalesInvoice/Templates/PrintData/Ext/Template.xml", 1),
+                ],
+            )
+            self.assertEqual(before, (target_admission.tree_manifest(snapshot), manifest.read_bytes()))
+
+    def test_result_is_byte_identical_deterministic_and_explicitly_truncated(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _, _, ref = create_target(root)
+
+            first = run_search(root, ref, "PaymentDueDate", "--mode", "literal", "--limit", "1", "--max-bytes", "600")
+            second = run_search(root, ref, "PaymentDueDate", "--mode", "literal", "--limit", "1", "--max-bytes", "600")
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(first.stdout, second.stdout)
+            self.assertLessEqual(len(first.stdout.encode("utf-8")), 600)
+            payload = json.loads(first.stdout)
+            self.assertTrue(payload["truncated"])
+            self.assertEqual(len(payload["results"]), 1)
+
+    def test_path_prefix_limits_search_to_declared_subtree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _, _, ref = create_target(root)
+
+            completed = run_search(
+                root,
+                ref,
+                "PaymentDueDate",
+                "--mode",
+                "literal",
+                "--path-prefix",
+                "Documents/SalesInvoice/Templates",
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(json.loads(completed.stdout)["results"], [{
+                "fragment": "<field><dataPath>PaymentDueDate</dataPath></field>",
+                "line": 1,
+                "path": "Documents/SalesInvoice/Templates/PrintData/Ext/Template.xml",
+            }])
+
+    def test_regex_invalid_request_and_unadmitted_ref_fail_closed_without_paths_or_trace(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _, _, ref = create_target(root)
+
+            invalid_regex = run_search(root, ref, "(", "--mode", "regex")
+            escaped_path = run_search(root, ref, "Posting", "--path-prefix", "../outside")
+            broken = json.loads(ref.read_text(encoding="utf-8"))
+            broken["snapshot"]["root"] = ".local/targets/other/snapshot"
+            ref.write_text(json.dumps(broken), encoding="utf-8")
+            unadmitted = run_search(root, ref, "Posting")
+
+            for completed, reason in ((invalid_regex, "invalid_request"), (escaped_path, "invalid_request"), (unadmitted, "snapshot_invalid")):
+                self.assertEqual(completed.returncode, 1)
+                payload = json.loads(completed.stdout)
+                self.assertEqual(payload["status"], "blocked")
+                self.assertEqual(payload["reasonCode"], reason)
+                self.assertNotIn(str(root), completed.stdout)
+                self.assertNotIn("Traceback", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_snapshot_search.py
+++ b/tests/test_snapshot_search.py
@@ -7,13 +7,16 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "scripts" / "snapshot_search.py"
 sys.path.insert(0, str(ROOT / "scripts"))
 
 import target_admission
+import snapshot_search
 
 
 def digest(payload: bytes) -> str:
@@ -127,6 +130,59 @@ class SnapshotSearchTests(unittest.TestCase):
             payload = json.loads(first.stdout)
             self.assertTrue(payload["truncated"])
             self.assertEqual(len(payload["results"]), 1)
+
+    def test_max_bytes_includes_the_final_stdout_newline(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _, _, ref = create_target(root)
+
+            baseline = run_search(root, ref, "PaymentDueDate", "--mode", "literal")
+            self.assertEqual(baseline.returncode, 0, baseline.stderr)
+            bounded = run_search(
+                root,
+                ref,
+                "PaymentDueDate",
+                "--mode",
+                "literal",
+                "--max-bytes",
+                str(len(baseline.stdout.encode("utf-8")) - 1),
+            )
+
+            self.assertEqual(bounded.returncode, 0, bounded.stderr)
+            self.assertLessEqual(
+                len(bounded.stdout.encode("utf-8")),
+                len(baseline.stdout.encode("utf-8")) - 1,
+            )
+            self.assertTrue(json.loads(bounded.stdout)["truncated"])
+
+    def test_manifest_entry_read_or_decode_failure_is_not_silently_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = Path(temporary)
+            with self.assertRaisesRegex(snapshot_search.SearchBlocked, "Snapshot content is unreadable"):
+                list(snapshot_search._matching_lines(
+                    snapshot,
+                    {"Documents/Missing/Ext/ObjectModule.bsl": "sha256:unused"},
+                    __import__("re").compile("Anything"),
+                    None,
+                ))
+
+    def test_deadline_interrupts_a_slow_post_admission_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _, _, ref = create_target(root)
+
+            admitted = snapshot_search._admitted_snapshot(root, ref)
+
+            def late_hits(*_args: object):
+                time.sleep(0.03)
+                if False:
+                    yield {}
+
+            with patch.object(snapshot_search, "SEARCH_DEADLINE_SECONDS", 0.01), patch.object(
+                snapshot_search, "_admitted_snapshot", return_value=admitted
+            ), patch.object(snapshot_search, "_matching_lines", late_hits):
+                with self.assertRaisesRegex(snapshot_search.SearchBlocked, "deadline"):
+                    snapshot_search.search(root, ref, "PaymentDueDate", "literal", None, 20, 32 * 1024)
 
     def test_path_prefix_limits_search_to_declared_subtree(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
Closes #67

## `SEARCH ROUTE READY`

A fresh Linux executor now follows one documented repo-owned route:

```bash
mkdir -p .local/search-session
python3 scripts/project_target.py open --repo-root . \
  > .local/search-session/snapshot-ref.json
python3 scripts/snapshot_search.py \
  --repo-root . \
  --snapshot-ref .local/search-session/snapshot-ref.json \
  --query 'Procedure\s+Posting' --mode regex \
  --path-prefix Documents/SalesInvoice/Ext
```

## Boundary

- `project_target open` remains the sole owner of source, contract, retained storage, and admission.
- New target-owned `resolve_snapshot_ref()` consumes the exact data-only reference and performs one retained-target admission before returning manifest-declared files.
- Search consumes that narrow resolver once; it no longer embeds target contract/storage logic, repeats post-search admission, or hard-codes a performance deadline.
- V1 deliberately searches only `.bsl` and `.xml`; no system `rg`, network, index, cache, parser, MCP, service, skill, or native 1C is involved.
- JSON stays deterministic and bounded (including final newline), with relative path/line/fragment, literal/regex, safe prefix, and fail-closed invalid input/content.

## Verification

- Focused tests: **7 PASS**.
- Full suite: **225 PASS**.
- Full suite with `PYTHONWARNINGS=error::DeprecationWarning`: **225 PASS**.
- `py_compile` and `git diff --check`: PASS.
- One final no-native/no-`rg` exact-head canary on retained JetTr: PASS.
  - warm `SnapshotRef`: reused;
  - BSL: `Documents/SalesInvoice/Ext/ObjectModule.bsl:14` — 3.064 s / 279 B;
  - metadata XML: `Documents/SalesInvoice.xml:5` — 2.953 s / 3,118 B;
  - print-data XML: `Documents/SalesInvoice/Templates/PrintData/Ext/Template.xml:109` — 2.981 s / 1,975 B;
  - repeat stdout byte-identical; manifest unchanged (`70972b5e…`); native/Xvfb before and after: 0.

Exact-head CI: [run 33902519361](https://github.com/Kwentin3/1c-agent-harness/actions/runs/33902519361) — Python 3.9 and 3.12 PASS. Draft remains open and unmerged for owner decision.
